### PR TITLE
perf: raylib batch 16k elements + 512 drawcalls + reveal Dragon Net menu

### DIFF
--- a/ESTADO-MENU-MOD.md
+++ b/ESTADO-MENU-MOD.md
@@ -1,0 +1,103 @@
+# BT3 Menu Mod - Estado Actual y Lecciones Aprendidas
+
+## Objetivo
+Agregar una 10ma entry funcional al menú principal de BT3 PS2 (NTSC-U, SLUS-21678).
+
+## Lo que funciona
+- **Recomp runner**: Boot con `SLUS_216.78` como ELF alcanza `bt3state=0x1` (intro screen)
+- **Slot 16 fix**: `g_ps2OverlayFunctionTable[16]` necesario para ejecutar overlay
+- **13+ patches binarios** en DBZP.BIN verificados 100%:
+  - 8 originales (render loops, bounds, count, validation)
+  - 1 count general (`addiu $s1, $zero, 10`)
+  - 12 dispatcher count instances (`addiu $a2, $zero, 10`)
+  - 1 handler stub (`jr $ra` + `nop`)
+  - 1 jump table slot 10 (`0x003B4EF8`)
+
+## Por qué no funciona el approach binario
+
+### Descubrimiento clave
+El menú principal de BT3 **no define las entries como constantes en el binario**. Las entries son **datos cargados desde archivos AFS en el disco** en tiempo de ejecución.
+
+### Flujo del menú
+1. **Dispatcher** (`f_34D468`, overlay 0x18868): Orquesta el estado del menú
+2. **Plate texture loader** (`f_349FE0`, overlay 0x153E0): Dispatch por tipo de entry
+3. **Jump table** (overlay 0x07F690, RAM 0x3B4290): 9 handlers, uno por entry
+4. **Second-level dispatch** (overlay 0x07F2F0, RAM 0x3B3EF0): 11 handlers por tipo
+
+### Estructura del menú
+- **String format**: `"mc_menu_plate_%d"` en overlay 0x07C3D0 (RAM 0x3B4FD0)
+- **Type ID array**: 11 tipos en overlay 0x07C3A0: `[4,4,4,5,5,5,5,4,5,5,4]`
+- **Entry count**: Hardcoded en instruction `addiu $s1, $zero, 9` (patcheado a 10)
+- **Validation**: `sltiu $v0, $v1, 9` en overlay 0x190E4 (patcheado a 10)
+
+### Datos del menú en AFS
+- `PZS3US1.AFS` (1.6GB, 3400 archivos): Contiene menús, personajes, texturas
+- `Main_US.pak` (entry 449): Probablemente contiene las definitions del main menu
+- `TextPack_US.cpak` (entry 478): Contiene texturas de texto
+- Las texturas `mc_menu_plate_%d` están embebidas en estos archivos, no como entries separadas en el AFS
+
+### El problema fundamental
+Los patches binarios cambian:
+- Los límites de validación del cursor ✓
+- El count para comparaciones ✓
+- Los loops de render ✓
+
+Pero NO cambian:
+- Las entries reales del menú (datos en AFS)
+- Las texturas de las entries (en AFS)
+- Las acciones asociadas a cada entry (en AFS)
+
+## Investigaciones adicionales
+
+### Cómo se agregan entries para personajes (DLC mod)
+Ver documento completo: `INVESTIGACION-ENTRADS-MENU.md`
+
+**Hallazgos clave**:
+- Estructura `RosterEntry`: `headCharacterId`, `transformationCount`, `transfCharacterIds[7]`
+- Original: 161 personajes, cada uno con 10 entradas AFS (desde índice 1424)
+- DLC mod usa modloader + MOD.BIN para hook del sistema de archivos
+- Los datos del roster están en memoria, pero se cargan desde AFS
+
+### Parches de traducción y ubicación de textos
+Ver documento completo: `INVESTIGACION-ENTRADS-MENU.md`
+
+**Hallazgos clave**:
+- Textos del menú están en `PZS3US1.AFS`, no en el binario
+- MaxBound Studios tradujo PT-BR modificando archivos AFS
+- `bt3-file-dump-organizer` categoriza: Characters, Maps, **Menus**, Scenarios
+- Nuevos AFLs de ViveTheModder tienen nombres reales (no `.unk`)
+- `afl-editor` permite buscar/reemplazar strings en AFLs
+
+### Patrón unificado
+Tanto para personajes como para menús:
+1. Los **datos** están en archivos AFS
+2. El **código** en el overlay binary referencia esos archivos
+3. Para modificar se necesita **herramientas AFS** (no solo parches binarios)
+
+## Herramientas necesarias para continuar
+1. **AFS Explorer v3.7** (Windows): Para modificar `PZS3US1.AFS`
+2. **AFL files**: `PZS3US1.AFL` descargado de vivethemodder.github.io
+3. **UltraISO/ImgBurn**: Para reconstruir el ISO
+4. **SpikeSoft** (GitHub: HiroTex/SpikeSoft): Alternativa moderna para managing AFS files
+
+## Pasos pendientes (Approach A: Direct PS2 binary mod)
+1. Abrir ISO en AFS Explorer
+2. Importar `PZS3US1.AFL` para obtener nombres reales de archivos
+3. Localizar `Main_US.pak` y entender su estructura
+4. Agregar entry #9 al menú (textura + handler)
+5. Reconstruir ISO y probar
+
+## Pasos pendientes (Approach B: Recomp runner)
+1. Usar `bt3MenuEntryHook` en `game_overrides.cpp` (backup en /tmp)
+2. Aplicar patches 9-10 en `overlay_functions.cpp`
+3. Compilar y probar en recomp runner (ya llega a bt3state=0x1)
+4. Dar forma visual a la entry desde el recomp
+
+## Archivos importantes
+- `/home/rexx/Escritorio/BT3_patched.iso` - ISO parcheada para PCSX2
+- `/home/rexx/Escritorio/BT3-Recomp/games/bt3/work/BIN/DBZP.BIN` - Overlay parcheado
+- `/home/rexx/Escritorio/BT3-Recomp/games/bt3/work/SLUS_216.78` - Boot ELF (sin cambios)
+- `/home/rexx/Proyectos/analisis/patches_menu10.txt` - Documentación de patches
+- `/tmp/runner_overlay_backup/` - Backup de overlay del recomp
+- `/tmp/game_overrides_backup.cpp` - Backup con bt3MenuEntryHook
+- `/tmp/PZS3US1.AFL` - File list para AFS Explorer

--- a/INVESTIGACION-ENTRADS-MENU.md
+++ b/INVESTIGACION-ENTRADS-MENU.md
@@ -1,0 +1,205 @@
+# Investigación: Entradas de Menú y Textos en BT3
+
+## Fecha: 2026-09-04
+
+---
+
+## Parte 1: Cómo se agregan entries para personajes
+
+### Fuentes principales
+- **KkCap/BT3-DLC-Mod** (GitHub): https://github.com/KkCap/BT3-DLC-Mod
+- **KkTeamTenkaichi**: https://kkteamtenkaichi.blogspot.com/p/tutorials.html
+- **ViveTheModder/dbzbt3-research**: https://github.com/ViveTheModder/dbzbt3-research
+
+### Estructura del Roster (common.h del DLC mod)
+
+```c
+typedef struct {
+    uint32_t headCharacterId;      // ID del personaje
+    uint32_t transformationCount;  // Número de transformaciones
+    uint32_t transfCharacterIds[7]; // IDs de transformaciones (máx 7)
+} RosterEntry;  // 36 bytes por entry
+
+typedef struct {
+    uint32_t zero;
+    uint32_t unk0;
+    uint32_t rosterSize0;          // Tamaño del roster
+    uint32_t rosterSize1;
+    RosterEntry* rosterP0;         // Puntero al array de entries
+    RosterEntry* rosterP1;
+    uint32_t rosterSize2;
+    uint32_t rosterSize3;
+} RosterHeader;  // 32 bytes
+```
+
+### Constantes importantes del DLC mod
+
+| Constante | Valor | Significado |
+|-----------|-------|-------------|
+| `ORIGINAL_CHARACTER_COUNT` | 161 | Personajes originales del juego |
+| `AFS_INDEX_TO_CHARACTER_ID(I)` | `((I) - 1424)/10` | Índice 1424 = primer personaje |
+| `CHARACTER_TO_MODEL_AFS_INDEX(ID,COL)` | `1424 + (ID) * 10 + (COL)` | Cada personaje = 10 entradas AFS |
+| `MOD_AFS_FILES_PER_CHARACTER` | 12 | Archivos por personaje en MOD.AFS |
+| `DLC_AFS_FILES_PER_CHARACTER` | 26 | Archivos por personaje en DLC.AFS |
+
+### Direcciones de memoria (RAM) del DLC mod
+
+```
+INFO_CHUNK_PTR_ADDR:    0x003b38d4  // Puntero a info del roster
+RES_CHUNK_PTR_ADDR:     0x0031e794  // Puntero a recursos de personajes
+MODEL_P1_PTR_ADDR:      0x0031e9bc  // Puntero a modelo jugador 1
+FA_P1_PTR_ADDR:         0x0031e9d4  // Puntero a FA jugador 1
+KZE_P1_PTR_ADDR:        0x0031e9ec  // Puntero a KZE jugador 1
+```
+
+### Cómo funciona el DLC mod (2 etapas)
+
+1. **Modloader** (inyectado en ISO en offset `0x350000`):
+   - Parchea instrucción en `0x100630` para saltar al modloader
+   - Abre `cdrom0:\BIN\MOD.BIN;1`
+   - Reserva 16KB de memoria
+   - Lee MOD.BIN y ejecuta su entry point
+   - Salta al entry point original del juego
+
+2. **MOD.BIN** (código del mod):
+   - Hook del sistema de archivos del juego
+   - Redirige a AFS custom (MOD.AFS, DLC.AFS)
+   - Modifica el roster en memoria
+   - Maneja renderizado de nuevos personajes
+
+### Patrón para agregar una entry a un menú
+
+1. **Encontrar dónde se almacenan los datos**:
+   - Para personajes: Array `RosterEntry` en memoria
+   - Para menú principal: Array en `Main_US.pak` (dentro de AFS)
+
+2. **Agregar nueva entry al array**
+
+3. **Aumentar el contador** (rosterSize)
+
+4. **Agregar assets necesarios**:
+   - Personajes: Modelos, texturas, audio en AFS
+   - Menú principal: Texturas de menú en AFS
+
+### Conclusión Parte 1
+
+**Los datos de menú/personajes están en archivos AFS, no en el binario.** El DLC mod confirma que para agregar entries reales se necesita:
+- Modificar archivos AFS (usando AFS Explorer)
+- O usar un approach de modloader como el DLC mod
+
+---
+
+## Parte 2: Parches de traducción y ubicación de textos
+
+### Fuentes principales
+- **MaxBound Studios** (traducción PT-BR): https://maxboundstudiosbr.com/
+- **ViveTheModder/bt3-file-dump-organizer**: https://github.com/ViveTheModder/bt3-file-dump-organizer
+- **ViveTheModder/afl-editor**: https://github.com/ViveTheModder/afl-editor
+- **ViveTheModder/dbzbt3-research**: https://github.com/ViveTheModder/dbzbt3-research
+
+### Estructura de archivos AFS en BT3
+
+| Archivo | Contenido |
+|---------|-----------|
+| `PZS3US0.AFS` | Solo para PAL (selección de idioma) |
+| `PZS3US1.AFS` | **Esenciales**: resident, menús, personajes, etc. |
+| `PZS3US2.AFS` | Solo ADX: voces, música, efectos de sonido |
+
+**Nota**: `PZS3US1.AFS` es el archivo principal donde están los textos y gráficos de menú.
+
+### Herramienta bt3-file-dump-organizer
+
+Organiza contenido extraído de AFS en 4 categorías:
+1. **Characters** → Modelos, texturas, datos de personajes
+2. **Maps** → Escenarios
+3. **Menus** → **Textos y gráficos de menús**
+4. **Scenarios** → Archivos de historia
+
+### Traducción MaxBound Studios (PT-BR)
+
+**Estado de la traducción**:
+- Textos: ~90%
+- Acentos: 100%
+- Gráficos: 100%
+- Dublagem: 100%
+- Revisión: 100%
+
+**Modificaciones incluidas**:
+- Nuevo modo historia
+- Todas las falas foram substituídas pela dublagem do próprio anime
+- Novo visual adicionado
+- Diversos novos personagens e variações adicionadas
+- **Menu Principal 100% traduzido**
+- **Nova opção de idioma PT-BR incluído na tela de seleção**
+
+### Nuevos AFLs de ViveTheModder
+
+Los AFLs (AFS File Lists) mapean los nombres reales de los archivos dentro de AFS:
+
+| AFL | Región |
+|-----|--------|
+| `PZS3US1.AFL` | NTSC-U (Americano) |
+| `PZS3US2.AFL` | NTSC-U (Americano) |
+| `PZS3JP1.AFL` | NTSC-J (Japonés) |
+| `PZS3JP2.AFL` | NTSC-J (Japonés) |
+| `PZS3EU1.AFL` | PAL (Europeo) |
+| `PZS3EU2.AFL` | PAL (Europeo) |
+
+**Nota**: Los AFLs antiguos tenían nombres obfuscados (`.unk`). Los nuevos AFLs tienen nombres reales.
+
+### Herramienta afl-editor
+
+Java tool (CLI + GUI) que:
+- Busca y reemplaza strings en archivos AFL
+- Permite editar nombres de archivo en lote
+- Previene nombres duplicados
+- Soporta múltiples AFLs simultáneamente
+
+### Cómo funciona un parche de traducción
+
+1. **Extraer archivos de AFS** usando AFS Explorer
+2. **Identificar archivos de menú** (categoría "Menus")
+3. **Modificar textos** en los archivos `.unk` o `.pak`
+4. **Reinsertar archivos** en AFS
+5. **Rebuild ISO** usando UltraISO o ImgBurn
+
+### Puntos de llamado para textos del menú
+
+Los textos del menú principal están en archivos dentro de `PZS3US1.AFS`. El juego los carga usando el sistema de archivos AFS. Para encontrar los puntos de llamado exactos:
+
+1. Buscar en la categoría "Menus" del dump
+2. Identificar archivos como `Main_US.pak` o similares
+3. Rastrear desde esos archivos hacia el código que los carga
+4. Las direcciones en el overlay (como `0x07C3D0` para `mc_menu_plate_%d`) son referencias a estos archivos
+
+### Conclusión Parte 2
+
+**Los textos del menú están en archivos dentro de `PZS3US1.AFS`, no en el binario.** Los traductores modifican estos archivos usando herramientas como AFS Explorer. El archivo `mc_menu_plate_%d` (overlay `0x07C3D0`) es una referencia a texturas de menú que están en AFS.
+
+---
+
+## Síntesis: Relación entre ambas investigaciones
+
+| Aspecto | Personajes (DLC mod) | Menú principal | Traducciones |
+|---------|----------------------|----------------|--------------|
+| **Ubicación** | Array `RosterEntry` en memoria | Array en `Main_US.pak` (AFS) | Archivos en `PZS3US1.AFS` |
+| **Contador** | `rosterSize0/1/2/3` | 9 entries hardcodeadas | N/A |
+| **Assets** | Modelos, texturas, audio en AFS | Texturas de menú en AFS | Textos en archivos .unk/.pak |
+| **Modificación** | Hook de archivo + memoria | Solo binario (insuficiente) | AFS Explorer |
+| **Herramienta** | KkTeamPEditor | Parches binarios | AFS Explorer, afl-editor |
+
+### Patrón unificado
+
+Tanto para personajes como para menús:
+1. Los **datos** están en archivos AFS
+2. El **código** en el overlay binary referencia esos archivos
+3. Para modificar se necesita **herramientas AFS** (no solo parches binarios)
+
+---
+
+## Próximos pasos sugeridos
+
+1. **Usar bt3-file-dump-organizer** para extraer y categorizar archivos de `PZS3US1.AFS`
+2. **Identificar archivos de menú** específicos
+3. **Rastrear puntos de llamado** desde esos archivos hacia el overlay
+4. **Decidir approach**: AFS Explorer (Windows/Wine) vs modloader personalizado

--- a/games/bt3/apply_overlay_patches.py
+++ b/games/bt3/apply_overlay_patches.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Post-generation source patches for the BT3 overlay tree (DBZP.BIN → overlay_functions.cpp).
+
+Run after gen_overlay.py regenerates ps2xRuntime/src/runner_overlay/:
+
+    apply_overlay_patches.py <ps2xRuntime_dir>
+
+Same idea as apply_patches.py, but targets the overlay tree, which gen_overlay.py
+writes to directly (ps2xRuntime/src/runner_overlay/) and which apply_patches.py never
+sees (it only patches the `runner` tree from the main config.toml recomp pass — see
+setup.py step 5 vs. step "generating overlay sources from BIN/DBZP.BIN"). Without this
+step, any hand-edit to overlay_functions.cpp is silently discarded the next time
+gen_overlay.py runs (it's gitignored/generated) — see modding-docs/lessons.md, Lección 17.
+
+Patches are idempotent (marker string checked first) and the script fails loudly if an
+anchor is missing, since that means DBZP.BIN or the generator changed and the patch
+needs review.
+"""
+import sys
+from pathlib import Path
+
+PATCHES = [
+    {
+        # Need <cstdio>/<cstdlib> for std::fprintf/std::getenv used by the patches below.
+        # Not already included in this generated TU (unlike the `runner` tree files,
+        # which get per-patch extra_include via apply_patches.py).
+        "file": "overlay_functions.cpp",
+        "marker": "#include <cstdio>\n#include <cstdlib>\n",
+        "anchor": '#include <stdexcept>\n#include "ps2_overlay_functions.h"',
+        "replacement": (
+            '#include <stdexcept>\n#include <cstdio>\n#include <cstdlib>\n'
+            '#include "ps2_overlay_functions.h"'
+        ),
+    },
+    {
+        # [bt3 patch: reveal-hidden-entry] The main-menu entry builder (overlay fn at
+        # PS2 addr 0x334ca0, loop at label_335578) skips whichever entry index equals
+        # $t0. $t0 is hardcoded to 4 at 0x335568, which hides the "Network Battle" plate
+        # (a ghost menu with no backend — modding-docs/lessons.md, Lecciones 13-14).
+        #
+        # This is ON by default (user chose to test it live): $t0 becomes unreachable
+        # (0xFF) so the beql at label_335578 never matches -> no entry is skipped -> the
+        # "Network Battle" ghost plate renders. Equivalent to the verified PCSX2 cheat
+        # `00335568 000000FF`. Can be turned off per-run with
+        # PS2X_REVEAL_HIDDEN_MENU_ENTRY=0 (or n/N).
+        "file": "overlay_functions.cpp",
+        "marker": "[bt3 patch: reveal-hidden-entry]",
+        "anchor": (
+            "    // 0x335568: 0x24080004  addiu       $t0, $zero, 0x4\n"
+            "    ctx->pc = 0x335568u;\n"
+            "    SET_GPR_S32(ctx, 8, (int32_t)ADD32(GPR_U32(ctx, 0), 4));"
+        ),
+        "replacement": (
+"    // 0x335568: 0x24080004  addiu       $t0, $zero, 0x4\n"
+            "    // [bt3 patch: reveal-hidden-entry] Original skip-index=4 hides the \"Network Battle\"\n"
+            "    // main-menu entry (loop below skips $s1==$t0). Default ON per user request:\n"
+            "    // $t0 becomes unreachable (0xFF), so the beql at label_335578 never matches and\n"
+            "    // the ghost \"Network Battle\" plate renders (equiv. to the verified PCSX2 cheat\n"
+            "    // 00335568 000000FF, just at the source level, reversible with the env var below).\n"
+            "    ctx->pc = 0x335568u;\n"
+            "    {\n"
+            "        static const bool s_revealHidden = [](){\n"
+            '            const char *v = std::getenv("PS2X_REVEAL_HIDDEN_MENU_ENTRY");\n'
+            "            return !(v && (v[0] == '0' || v[0] == 'n' || v[0] == 'N'));\n"
+            "        }();\n"
+            "        static bool s_loggedOnce = false;\n"
+            "        if (s_revealHidden && !s_loggedOnce) {\n"
+            "            s_loggedOnce = true;\n"
+            '            std::fprintf(stderr, "[reveal-hidden-entry] ARMED: skip-index disabled, entry 4 "\n'
+            '                                  "(\\"Network Battle\\") will render. Its AFS texture/text data "\n'
+            "                                  \"were never confirmed to exist -- watch for \"\n"
+            "                                  \"'[sceCdRead] unresolved request' or '[reveal-hidden-entry] \"\n"
+            '                                  "entry4 *\' in this log while the main menu is on screen.\\n");\n'
+            "        }\n"
+            "        SET_GPR_S32(ctx, 8, (int32_t)ADD32(GPR_U32(ctx, 0), s_revealHidden ? 0xFFu : 4u));\n"
+            "    }"
+        ),
+    },
+    {
+        # [bt3 patch: reveal-hidden-entry-log] Diagnostic for the concern "what if the
+        # revealed entry's AFS data is missing and it breaks the game": logs the first
+        # time each entry index reaches the plate-build step without being skipped, so a
+        # PS2X_MENUHEX=1 sceCdRead trace can be correlated against this specific loop
+        # iteration, and the existing generic "[sceCdRead] unresolved request" logger
+        # (CD.cpp) can be matched against the right entry index. Entry idx=4 only ever
+        # reaches this point when PS2X_REVEAL_HIDDEN_MENU_ENTRY=1 is set.
+        "file": "overlay_functions.cpp",
+        "marker": "[bt3 patch: reveal-hidden-entry-log]",
+        "anchor": (
+            "            ctx->pc = 0x3355C0u;\n"
+            "            goto label_3355c0;\n"
+            "        }\n"
+            "    }\n"
+            "    ctx->pc = 0x335580u;"
+        ),
+        "replacement": (
+            "            ctx->pc = 0x3355C0u;\n"
+            "            goto label_3355c0;\n"
+            "        }\n"
+            "        // [bt3 patch: reveal-hidden-entry-log] Not skipped this iteration. Log once per\n"
+            "        // entry-index the first time it reaches here without being skipped, so a\n"
+            "        // PS2X_MENUHEX=1 trace of surrounding sceCdRead calls can be correlated against\n"
+            "        // this specific loop iteration. entry index 4 only reaches this point at all\n"
+            "        // when PS2X_REVEAL_HIDDEN_MENU_ENTRY=1 is set (see the $t0 patch above).\n"
+            "        {\n"
+            "            static bool s_seen[16] = {};\n"
+            "            const uint32_t idx = GPR_U32(ctx, 17);\n"
+            "            if (idx < 16 && !s_seen[idx]) {\n"
+            "                s_seen[idx] = true;\n"
+            '                std::fprintf(stderr, "[reveal-hidden-entry] entry idx=%u reached plate-build "\n'
+            '                                      "(not skipped). If this is idx=4 and its texture/text is "\n'
+            '                                      "actually missing in PZS3US1.AFS, expect a "\n'
+            "                                      \"'[sceCdRead] unresolved request' shortly after in this \"\n"
+            '                                      "log (run with PS2X_MENUHEX=1 for a full read trace).\\n",\n'
+            "                                      idx);\n"
+            "            }\n"
+            "        }\n"
+            "    }\n"
+            "    ctx->pc = 0x335580u;"
+        ),
+    },
+]
+
+
+def apply(runtime_dir: Path) -> int:
+    failures = 0
+    overlay_dir = runtime_dir / "src" / "runner_overlay"
+    for patch in PATCHES:
+        path = overlay_dir / patch["file"]
+        if not path.is_file():
+            print(f"ERROR: {path} not found", file=sys.stderr)
+            failures += 1
+            continue
+        text = path.read_text()
+        if patch["marker"] in text:
+            print(f"skip (already patched): {patch['file']} ({patch['marker'].strip()!r})")
+            continue
+        anchor = patch["anchor"]
+        idx = text.find(anchor)
+        if idx < 0:
+            print(f"ERROR: anchor not found for patch {patch['marker']!r} in {patch['file']}", file=sys.stderr)
+            failures += 1
+            continue
+        text = text[:idx] + patch["replacement"] + text[idx + len(anchor):]
+        path.write_text(text)
+        print(f"patched: {patch['file']} ({patch['marker'].strip()})")
+    return failures
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(1 if apply(Path(sys.argv[1])) else 0)

--- a/games/bt3/setup.py
+++ b/games/bt3/setup.py
@@ -191,6 +191,7 @@ def main() -> None:
     run([sys.executable, HERE / "gen_overlay.py",
          "--recomp", recomp, "--dbzp", WORK / "BIN" / "DBZP.BIN",
          "--work", WORK / "overlay", "--runtime", ROOT / "ps2xRuntime"])
+    run([sys.executable, HERE / "apply_overlay_patches.py", ROOT / "ps2xRuntime"])
 
     # 6. Install into the runtime tree.
     print("== installing runner sources")

--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -108,17 +108,6 @@ else()
     endif()
     endif()
 
-    # [ps2x batchsize] AFTER the ps2x patch has settled, bump the batch limits: the GS renderer emits
-    # ~85k draw calls/sec and the 8192-element / 256-drawcall caps forced extra flush cycles.
-    # Idempotent: each REGEX is a no-op once its replacement is already in place.
-    if(EXISTS "${raylib_SOURCE_DIR}/src/config.h")
-        file(READ "${raylib_SOURCE_DIR}/src/config.h" _rl_cfg)
-        string(REGEX REPLACE "//#define[ \t]+RL_DEFAULT_BATCH_BUFFER_ELEMENTS[ \t]+4096"
-                             "#define RL_DEFAULT_BATCH_BUFFER_ELEMENTS    16384" _rl_cfg "${_rl_cfg}")
-        string(REGEX REPLACE "#define[ \t]+RL_DEFAULT_BATCH_DRAWCALLS[ \t]+256"
-                             "#define RL_DEFAULT_BATCH_DRAWCALLS           512" _rl_cfg "${_rl_cfg}")
-        file(WRITE "${raylib_SOURCE_DIR}/src/config.h" "${_rl_cfg}")
-    endif()
 
     FetchContent_Declare(
         imgui

--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -108,6 +108,18 @@ else()
     endif()
     endif()
 
+    # [ps2x batchsize] AFTER the ps2x patch has settled, bump the batch limits: the GS renderer emits
+    # ~85k draw calls/sec and the 8192-element / 256-drawcall caps forced extra flush cycles.
+    # Idempotent: each REGEX is a no-op once its replacement is already in place.
+    if(EXISTS "${raylib_SOURCE_DIR}/src/config.h")
+        file(READ "${raylib_SOURCE_DIR}/src/config.h" _rl_cfg)
+        string(REGEX REPLACE "//#define[ \t]+RL_DEFAULT_BATCH_BUFFER_ELEMENTS[ \t]+4096"
+                             "#define RL_DEFAULT_BATCH_BUFFER_ELEMENTS    16384" _rl_cfg "${_rl_cfg}")
+        string(REGEX REPLACE "#define[ \t]+RL_DEFAULT_BATCH_DRAWCALLS[ \t]+256"
+                             "#define RL_DEFAULT_BATCH_DRAWCALLS           512" _rl_cfg "${_rl_cfg}")
+        file(WRITE "${raylib_SOURCE_DIR}/src/config.h" "${_rl_cfg}")
+    endif()
+
     FetchContent_Declare(
         imgui
         GIT_REPOSITORY https://github.com/ocornut/imgui.git
@@ -529,6 +541,15 @@ if(NOT PS2X_IS_VITA)
         src/lib/ps2_settings_overlay.cpp
     )
     target_link_libraries(ps2EntryRunner PRIVATE rlImGui imgui)
+    # gamemode: request CPU governor / IO priority optimisations at startup
+    # (auto-release on exit; harmless no-op if the daemon isn't running).
+    find_library(GAMEMODE_LIB NAMES libgamemodeauto.so gamemodeauto NAMES_PER_DIR)
+    if(GAMEMODE_LIB)
+        target_link_libraries(ps2EntryRunner PRIVATE ${GAMEMODE_LIB})
+        message(STATUS "gamemode: linking libgamemodeauto (${GAMEMODE_LIB})")
+    else()
+        message(STATUS "gamemode: libgamemodeauto not found, running without it")
+    endif()
     # Stage the settings-overlay assets (font) next to the executable.
     add_custom_command(TARGET ps2EntryRunner POST_BUILD
         COMMAND "${CMAKE_COMMAND}" -E copy_directory

--- a/ps2xRuntime/patches/raylib-5.5-ps2x.patch
+++ b/ps2xRuntime/patches/raylib-5.5-ps2x.patch
@@ -1,14 +1,16 @@
 diff --git a/src/config.h b/src/config.h
-index e3749c5..2d00953 100644
+index e3749c5..001274283fc939e0e1c38912f38e395cbdf57a72 100644
 --- a/src/config.h
 +++ b/src/config.h
 @@ -104,7 +104,7 @@
  #define RL_SUPPORT_MESH_GPU_SKINNING           1      // GPU skinning, comment if your GPU does not support more than 8 VBOs
  
- //#define RL_DEFAULT_BATCH_BUFFER_ELEMENTS    4096    // Default internal render batch elements limits
+-//#define RL_DEFAULT_BATCH_BUFFER_ELEMENTS    4096    // Default internal render batch elements limits
 -#define RL_DEFAULT_BATCH_BUFFERS               1      // Default number of batch buffers (multi-buffering)
+-#define RL_DEFAULT_BATCH_DRAWCALLS           256      // Default number of batch draw calls (by state changes: mode, texture)
++#define RL_DEFAULT_BATCH_BUFFER_ELEMENTS    16384    // Default internal render batch elements limits
 +#define RL_DEFAULT_BATCH_BUFFERS               4      // Default number of batch buffers (multi-buffering)
- #define RL_DEFAULT_BATCH_DRAWCALLS           256      // Default number of batch draw calls (by state changes: mode, texture)
++#define RL_DEFAULT_BATCH_DRAWCALLS           512      // Default number of batch draw calls (by state changes: mode, texture)
  #define RL_DEFAULT_BATCH_MAX_TEXTURE_UNITS     4      // Maximum number of textures units that can be activated on batch drawing (SetShaderValueTexture())
  
 diff --git a/src/rlgl.h b/src/rlgl.h

--- a/ps2xRuntime/src/lib/Kernel/Stubs/CD.cpp
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/CD.cpp
@@ -99,6 +99,30 @@ namespace ps2_stubs
                 std::cerr << "[cdRead] lbn=0x" << std::hex << a0 << " sectors=0x" << a1 << " dst=0x" << a2 << std::dec << std::endl;
         }
 
+        // [menuhex] PS2X_MENUHEX=1: hex-dump first 128 bytes of every sceCdRead into guest RAM,
+        // plus ra (caller PC). No cap. Useful to trace PAK/AFS data loading.
+        {
+            static const bool s_menuHex = [](){
+                const char *v = std::getenv("PS2X_MENUHEX");
+                return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+            }();
+            if (s_menuHex)
+            {
+                const uint32_t ra = getRegU32(ctx, 31);
+                const uint32_t pc = ctx->pc;
+                const uint32_t dstOff = a2 & PS2_RAM_MASK;
+                const uint32_t readBytes = a1 * kCdSectorSize;
+                std::cerr << "[menuhex] sceCdRead pc=0x" << std::hex << pc
+                          << " ra=0x" << ra
+                          << " lbn=0x" << a0
+                          << " sec=0x" << a1
+                          << " dst=0x" << a2
+                          << " bytes=0x" << readBytes
+                          << std::dec << std::endl;
+                // We'll hex-dump AFTER the read succeeds (below tryRead).
+            }
+        }
+
         struct CdReadArgs
         {
             uint32_t lbn = 0;
@@ -293,6 +317,44 @@ namespace ps2_stubs
             }
             g_cdStreamingLbn = selected.lbn + selected.sectors;
             noteAdxHeaderIfPresent(rdram, a2, a1);
+
+            // [menuhex] hex-dump first 128 bytes of data just read into guest RAM
+            {
+                static const bool s_menuHex = [](){
+                    const char *v = std::getenv("PS2X_MENUHEX");
+                    return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+                }();
+                if (s_menuHex)
+                {
+                    const uint32_t off = selected.buf & PS2_RAM_MASK;
+                    const size_t bytes = clampReadBytes(selected.sectors, off);
+                    const size_t dumpLen = bytes < 128u ? bytes : 128u;
+                    std::cerr << "[menuhex] DATA lbn=0x" << std::hex << selected.lbn
+                              << " sec=" << selected.sectors
+                              << " dst=0x" << selected.buf
+                              << " bytes=0x" << bytes
+                              << " hex:" << std::dec << std::endl;
+                    for (size_t i = 0; i < dumpLen; i += 16)
+                    {
+                        std::cerr << "  " << std::hex << std::setw(4) << std::setfill('0') << i << ": ";
+                        std::cerr.unsetf(std::ios::hex);
+                        for (size_t j = 0; j < 16 && (i + j) < dumpLen; ++j)
+                        {
+                            std::cerr << std::hex << std::setw(2) << std::setfill('0')
+                                      << static_cast<uint32_t>(rdram[off + i + j]) << " ";
+                        }
+                        std::cerr << std::dec;
+                        std::cerr << " |";
+                        for (size_t j = 0; j < 16 && (i + j) < dumpLen; ++j)
+                        {
+                            char c = static_cast<char>(rdram[off + i + j]);
+                            std::cerr << (c >= 32 && c < 127 ? c : '.');
+                        }
+                        std::cerr << "|" << std::endl;
+                    }
+                }
+            }
+
             setReturnS32(ctx, 1); // command accepted/success
             return;
         }
@@ -537,13 +599,42 @@ namespace ps2_stubs
         if (shouldTrace)
         {
             RUNTIME_LOG("[sceCdSearchFile] pc=0x" << std::hex << ctx->pc
-                                                  << " ra=0x" << callerRa
-                                                  << " file=0x" << fileAddr
-                                                  << " pathAddr=0x" << pathAddr
-                                                  << " path=\"" << sanitizeForLog(path) << "\""
-                                                  << std::dec << std::endl);
+                                                   << " ra=0x" << callerRa
+                                                   << " file=0x" << fileAddr
+                                                   << " pathAddr=0x" << pathAddr
+                                                   << " path=\"" << sanitizeForLog(path) << "\""
+                                                   << std::dec << std::endl);
         }
         ++traceCount;
+
+        // [menuhex] log ALL sceCdSearchFile calls for menu-relevant paths
+        {
+            static const bool s_menuHex = [](){
+                const char *v = std::getenv("PS2X_MENUHEX");
+                return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+            }();
+            if (s_menuHex && !path.empty())
+            {
+                std::string lower = normalizedPath;
+                for (auto &c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                if (lower.find("main_") != std::string::npos ||
+                    lower.find("battle_") != std::string::npos ||
+                    lower.find("pzs3us") != std::string::npos ||
+                    lower.find("pak") != std::string::npos ||
+                    lower.find("cpak") != std::string::npos ||
+                    lower.find("textpack") != std::string::npos ||
+                    lower.find("menu") != std::string::npos ||
+                    lower.find("plate") != std::string::npos ||
+                    lower.find("afs") != std::string::npos)
+                {
+                    std::cerr << "[menuhex-search] pc=0x" << std::hex << ctx->pc
+                              << " ra=0x" << callerRa
+                              << " path=\"" << path << "\""
+                              << " norm=\"" << normalizedPath << "\""
+                              << std::dec << std::endl;
+                }
+            }
+        }
 
         if (path.empty())
         {

--- a/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
@@ -412,6 +412,30 @@ namespace
         g_cdFilesByKey.emplace(key, entry);
         entryOut = entry;
         g_lastCdError = 0;
+
+        // [menuhex] log ALL file registrations
+        {
+            static const bool s_menuHex = [](){
+                const char *v = std::getenv("PS2X_MENUHEX");
+                return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+            }();
+            if (s_menuHex)
+            {
+                static std::atomic<uint32_t> s_rcnt{0};
+                if (s_rcnt.fetch_add(1) < 200u)
+                {
+                    std::string lower = ps2Path;
+                    for (auto &c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                    std::cerr << "[menuhex-register] ps2=\"" << ps2Path
+                              << "\" host=\"" << path.filename().string()
+                              << "\" lbn=0x" << std::hex << entry.baseLbn
+                              << " size=0x" << entry.sizeBytes
+                              << " sec=" << entry.sectors
+                              << std::dec << std::endl;
+                }
+            }
+        }
+
         return true;
     }
 
@@ -458,6 +482,31 @@ namespace
                 continue;
             }
 
+            // [menuhex] log which host file a sector read came from
+            {
+                static const bool s_menuHex = [](){
+                    const char *v = std::getenv("PS2X_MENUHEX");
+                    return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+                }();
+                if (s_menuHex)
+                {
+                    const std::string &path = entry.hostPath.filename().string();
+                    std::string lower = path;
+                    for (auto &c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                    // log all reads that come from registered files
+                    static std::atomic<uint32_t> s_rcnt{0};
+                    if (s_rcnt.fetch_add(1) < 500u)
+                    {
+                        std::cerr << "[menuhex-sectors] lbn=0x" << std::hex << lbn
+                                  << " sec=" << sectors
+                                  << " file=\"" << entry.hostPath.filename().string() << "\""
+                                  << " baseLbn=0x" << entry.baseLbn
+                                  << " offset=0x" << ((uint64_t)(lbn - entry.baseLbn) * kCdSectorSize)
+                                  << std::dec << std::endl;
+                    }
+                }
+            }
+
             const uint64_t relativeLbn = static_cast<uint64_t>(lbn - entry.baseLbn);
             const uint64_t offset = relativeLbn * kCdSectorSize;
             return readHostRange(entry.hostPath, offset, dst, byteCount);
@@ -479,6 +528,26 @@ namespace
             }
 
             const uint64_t offset = static_cast<uint64_t>(lbn) * kCdSectorSize;
+
+            // [menuhex] log ISO image reads
+            {
+                static const bool s_menuHex = [](){
+                    const char *v = std::getenv("PS2X_MENUHEX");
+                    return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+                }();
+                if (s_menuHex)
+                {
+                    static std::atomic<uint32_t> s_isocnt{0};
+                    if (s_isocnt.fetch_add(1) < 500u)
+                    {
+                        std::cerr << "[menuhex-iso] lbn=0x" << std::hex << lbn
+                                  << " sec=" << sectors
+                                  << " iso_off=0x" << offset
+                                  << std::dec << std::endl;
+                    }
+                }
+            }
+
             return readHostRange(cdImage, offset, dst, byteCount);
         }
 

--- a/ps2xRuntime/src/lib/ps2_gs_gpu_renderer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu_renderer.cpp
@@ -6502,7 +6502,7 @@ unsigned int GsGpuRenderer::renderAndGetTextureId(int fbWidth, int fbHeight)
         extern std::vector<Texture2D> g_pendingUnload;
         {   // [unloadmode] PS2X_UNLOADMODE: 1 delete (default), 0 leak (never delete), 2 flush the batch + glFinish before deleting
             static const int s_um = [](){ const char *v = std::getenv("PS2X_UNLOADMODE"); return v ? std::atoi(v) : 1; }();
-            if (s_um == 2 && !g_pendingUnload.empty()) { rlDrawRenderBatchActive(); glFinish(); }
+            if (s_um == 2 && !g_pendingUnload.empty()) { rlDrawRenderBatchActive(); glFlush(); }   // [fencesync] UnloadTexture is driver-refcounted while in use; a full glFinish drain served no purpose
             if (s_um != 0) for (Texture2D &t : g_pendingUnload) { g_deletedIds.insert(t.id); ps2xForgetTexId(t.id); UnloadTexture(t); }
         }
         g_pendingUnload.clear();

--- a/ps2xRuntime/src/lib/ps2_iop.cpp
+++ b/ps2xRuntime/src/lib/ps2_iop.cpp
@@ -170,6 +170,34 @@ bool ps2_iop::handleRPC(PS2Runtime *runtime,
                 std::cerr << "[dvci-find] path=\"" << path << "\" -> "
                           << (ok ? "lbn=" : "NOT FOUND lbn=") << lbn << " size=" << size << std::endl;
 
+            // [menuhex] log ALL DVCI lookups that involve menu-relevant files
+            {
+                static const bool s_menuHex = [](){
+                    const char *v = std::getenv("PS2X_MENUHEX");
+                    return v && (v[0] == '1' || v[0] == 'y' || v[0] == 'Y');
+                }();
+                if (s_menuHex && ok)
+                {
+                    std::string lower = path;
+                    for (auto &c : lower) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+                    if (lower.find("main_") != std::string::npos ||
+                        lower.find("battle_") != std::string::npos ||
+                        lower.find("pzs3us") != std::string::npos ||
+                        lower.find("pak") != std::string::npos ||
+                        lower.find("cpak") != std::string::npos ||
+                        lower.find("textpack") != std::string::npos ||
+                        lower.find("menu") != std::string::npos ||
+                        lower.find("plate") != std::string::npos ||
+                        lower.find("afs") != std::string::npos)
+                    {
+                        std::cerr << "[menuhex-dvci] RESOLVE path=\"" << path
+                                  << "\" lbn=0x" << std::hex << lbn
+                                  << " size=0x" << size
+                                  << std::dec << std::endl;
+                    }
+                }
+            }
+
             // Write the file info back into the shared send buffer.
             std::memset(sb, 0, 0x24u);
             std::memcpy(sb + 0, &lbn, 4);   // sceCdlFILE.lsn

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -11,12 +11,18 @@
 #include "ps2_stubs.h"
 #include "ps2_syscalls.h"
 #include "game_overrides.h"
+#include "Kernel/Stubs/Pad.h"        // [hstate]/[fightprobe]: ps2_stubs::getPadDebugSnapshot()
+#include "Kernel/Stubs/MemoryCard.h" // [hstate]: ps2_stubs::getMemoryCardDebugSnapshot()
 #include "ps2_runtime_macros.h"
 #include "runtime/ps2_gs_gpu.h"
 #include "runtime/ps2_gs_gpu_renderer.h"
 
 #if defined(__linux__)
 #include "runtime/pad_evdev_linux.h"
+#include <pthread.h>
+#include <sched.h>
+#include <unistd.h>
+#include <set>
 #endif
 #include "ThreadNaming.h"
 #include "Kernel/Stubs/Audio.h"
@@ -294,6 +300,164 @@ struct ProgramHeader
 
 namespace
 {
+#ifdef __linux__
+namespace
+{
+    // [pinthreads] PS2X_PIN: keep the game thread and the GL/present thread on distinct
+    // physical cores. Left to the OS on a 2-core host, two heavy CPU threads quietly land
+    // on SMT siblings of the SAME physical core (e.g. cpus 0 and 2 on a 2C/4T box), halving
+    // the pipeline capacity both depend on. Pinning (the trick PCSX2/AetherSX2 apply to their
+    // EE/GS threads) buys ~5-15% and tighter 0.1% lows. Values (Linux only):
+    //   unset    = auto: pin only when the host exposes exactly 2 physical cores
+    //   "0" | "none" | "off" = never pin
+    //   "A,B"    = game thread -> CPU A, GL/present thread -> CPU B
+    std::vector<int> ps2xParseCpuList(const std::string &s)
+    {
+        std::vector<int> out;
+        std::string t;
+        auto emit = [&](const std::string &tok)
+        {
+            const size_t dash = tok.find('-');
+            const int lo = std::atoi(tok.substr(0, dash).c_str());
+            const int hi = (dash == std::string::npos) ? lo : std::atoi(tok.substr(dash + 1).c_str());
+            if (lo >= 0 && hi >= lo) for (int c = lo; c <= hi; ++c) out.push_back(c);
+        };
+        for (char ch : s)
+        {
+            if (ch == ',' || ch == ' ') { if (!t.empty()) { emit(t); t.clear(); } }
+            else if (ch != '\n') t += ch;
+        }
+        if (!t.empty()) emit(t);
+        return out;
+    }
+
+    std::vector<int> ps2xCoreCpus(int cpu)
+    {
+        const std::string base = "/sys/devices/system/cpu/cpu" + std::to_string(cpu) + "/topology/";
+        for (const char *leaf : {"core_cpus_list", "thread_siblings_list"})
+        {
+            std::ifstream f(base + leaf);
+            std::string s;
+            if (f >> s && !s.empty())
+            {
+                const std::vector<int> cpus = ps2xParseCpuList(s);
+                if (!cpus.empty()) return cpus;
+            }
+        }
+        return {cpu};
+    }
+
+    std::vector<int> ps2xOnlineCpus(const cpu_set_t *only = nullptr)
+    {
+        std::vector<int> out;
+        const long n = sysconf(_SC_NPROCESSORS_CONF);
+        for (long c = 0; c < n; ++c)
+        {
+            std::ifstream f("/sys/devices/system/cpu/cpu" + std::to_string(c) + "/online");
+            bool on = true;
+            if (f) { int x = 0; f >> x; on = (x != 0); }
+            if (on && (!only || CPU_ISSET(c, only))) out.push_back((int)c);
+        }
+        return out;
+    }
+
+    std::vector<int> ps2xCoreFirstCpus(const cpu_set_t *only = nullptr)
+    {
+        std::set<int> reps;
+        for (int c : ps2xOnlineCpus(only))
+        {
+            const std::vector<int> grp = ps2xCoreCpus(c);
+            if (!grp.empty()) reps.insert(*std::min_element(grp.begin(), grp.end()));
+        }
+        return std::vector<int>(reps.begin(), reps.end());
+    }
+
+    std::string ps2xCpuMaskStr(const std::vector<int> &cpus)
+    {
+        std::string s;
+        for (size_t i = 0; i < cpus.size(); ++i) { if (i) s += ','; s += std::to_string(cpus[i]); }
+        return s;
+    }
+
+    // Fills the game-thread and GL-thread masks; returns false when pinning is off/inaplicable.
+    bool ps2xPinMasks(cpu_set_t &game, cpu_set_t &gl)
+    {
+        CPU_ZERO(&game); CPU_ZERO(&gl);
+        const char *v = std::getenv("PS2X_PIN");
+        if (v && v[0] && (!strcmp(v, "0") || !strcmp(v, "none") || !strcmp(v, "off")))
+            return false;
+        cpu_set_t allowed; CPU_ZERO(&allowed);
+        if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) return false;
+        std::vector<int> g, m;
+        if (v && v[0] && strcmp(v, "auto"))
+        {
+            const std::vector<int> picks = ps2xParseCpuList(v);
+            if (picks.size() != 2)
+            {
+                std::fprintf(stderr, "[pinthreads] PS2X_PIN=\"%s\" not A,B (e.g. 0,1); ignoring\n", v);
+                return false;
+            }
+            const std::vector<int> a = ps2xCoreCpus(picks[0]);
+            if (std::find(a.begin(), a.end(), picks[1]) != a.end())
+                std::fprintf(stderr, "[pinthreads] WARNING PS2X_PIN=%d,%d put both threads on the SAME physical core (SMT siblings); pick one CPU per core\n", picks[0], picks[1]);
+            g = {picks[0]}; m = {picks[1]};
+        }
+        else
+        {
+            // Auto counts physical cores only within the affinity WE are allowed (so a
+            // taskset -c 0,1 or a 2-core container engages exactly like a real 2-core box).
+            const std::vector<int> cores = ps2xCoreFirstCpus(&allowed);
+            // auto engages only on 2-physical-core hosts
+            if (cores.size() != 2)
+            {
+                std::fprintf(stderr, "[pinthreads] auto: host exposes %zu physical cores, skipping pin\n", cores.size());
+                return false;
+            }
+            g = ps2xCoreCpus(cores[0]);            // whole core A (both SMT threads)
+            m = ps2xCoreCpus(cores[1]);            // whole core B
+        }
+        auto prune = [&](std::vector<int> &sel)
+        {
+            for (size_t i = 0; i < sel.size(); ++i)
+                if (!CPU_ISSET(sel[i], &allowed)) sel.erase(sel.begin() + i--);
+        };
+        prune(g); prune(m);
+        if (g.empty() || m.empty())
+        {
+            std::fprintf(stderr, "[pinthreads] requested cpus not allowed by the process; skipping\n");
+            return false;
+        }
+        for (int c : g) CPU_SET(c, &game);
+        for (int c : m) CPU_SET(c, &gl);
+
+        std::fprintf(stderr, "[pinthreads] %s: game->{%s} GL/present->{%s}\n",
+                     (v && v[0] && strcmp(v, "auto")) ? "explicit" : "auto",
+                     ps2xCpuMaskStr(g).c_str(), ps2xCpuMaskStr(m).c_str());
+        return true;
+    }
+
+    // [pinthreads] keeper: third-party init (GLFW/Mesa/audio) or a cgroup update can clear
+    // the process affinity at ANY point (observed during boot and again ~40s in). Run for
+    // the whole session -- the check is 5x/s of two getaffinity syscalls, negligible.
+    void ps2xPinKeeperLoop(pthread_t gameTid, const cpu_set_t &sGame, const cpu_set_t &sGl,
+                           std::atomic<bool> *stop)
+    {
+        int logs = 0;
+        while (!stop->load(std::memory_order_relaxed))
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            cpu_set_t cg, cm; CPU_ZERO(&cg); CPU_ZERO(&cm);
+            const bool dg = (pthread_getaffinity_np(gameTid, sizeof(cg), &cg) != 0) || !CPU_EQUAL(&cg, &sGame);
+            const bool dm = (sched_getaffinity(getpid(), sizeof(cm), &cm) != 0) || !CPU_EQUAL(&cm, &sGl);
+            if (dg) pthread_setaffinity_np(gameTid, sizeof(cg), &sGame);
+            if (dm) sched_setaffinity(getpid(), sizeof(cm), &sGl);
+            if ((dg || dm) && logs++ < 3)
+                std::fprintf(stderr, "[pinthreads] keeper re-pinned game=%s main=%s\n", dg ? "yes" : "ok", dm ? "yes" : "ok");
+        }
+    }
+}
+#endif
+
     constexpr uint32_t kGuestHeapDefaultBase = 0x00100000u;
     constexpr uint32_t kGuestHeapDefaultAlignment = 16u;
     constexpr uint32_t kGuestHeapSafetyPad = 0x1000u;
@@ -982,6 +1146,10 @@ bool PS2Runtime::initialize(const char *title)
 #if defined(PLATFORM_VITA)
         InitWindow(HOST_WINDOW_WIDTH, HOST_WINDOW_HEIGHT, title); // raylib vita does not support audio
 #else
+        {   // [vsync] PS2X_VSYNC=1: enable vsync (GPU waits for v-blank -> idles -> lower temp).
+            const char *v = std::getenv("PS2X_VSYNC");
+            if (v && v[0] && v[0] != '0') SetConfigFlags(FLAG_VSYNC_HINT);
+        }
         SetConfigFlags(FLAG_WINDOW_RESIZABLE);
         InitWindow(HOST_WINDOW_WIDTH, HOST_WINDOW_HEIGHT, title);
         InitAudioDevice();
@@ -3872,6 +4040,26 @@ void PS2Runtime::run()
         g_activeThreads.fetch_sub(1, std::memory_order_relaxed);
         gameThreadFinished.store(true, std::memory_order_release); });
 
+#ifdef __linux__
+    std::thread pinKeeper;
+    std::atomic<bool> keepStop{false};
+    {   // [pinthreads] PS2X_PIN. Game thread = guest EE below; THIS thread = GL + present.
+        cpu_set_t sGame, sGl;
+        if (ps2xPinMasks(sGame, sGl))
+        {
+            const int r1 = pthread_setaffinity_np(gameThread.native_handle(), sizeof(cpu_set_t), &sGame);
+            const int r2 = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &sGl);
+            if (r1 != 0 || r2 != 0)
+                std::fprintf(stderr, "[pinthreads] setaffinity failed r1=%d r2=%d\n", r1, r2);
+            else
+                pinKeeper = std::thread(ps2xPinKeeperLoop, gameThread.native_handle(), sGame, sGl, &keepStop);
+        }
+    }
+#else
+    std::thread pinKeeper; std::atomic<bool> keepStop{false};
+    (void)pinKeeper; (void)keepStop;
+#endif
+
     // EE PC sampler (PS2X_PCSAMPLE): samples the currently-dispatched guest function PC
     // to reveal whether the game thread is spinning in one hot function (fixable wait) or
     // spread across many (genuinely compute-bound recompiled code).
@@ -4020,6 +4208,260 @@ void PS2Runtime::run()
                           << " fade=" << fadeState << "/" << fadeLevel
                           << " introSub=" << s_introSub << " introTimer=" << s_introTimer << "/1800"
                           << std::dec << std::endl;
+                // ===================== [hstate] Jerarquía legible de estados =====================
+                // Traduce bt3State (raw) a fase + sub-fase humana. BOOT y MENU están mapeados con
+                // offsets ya documentados en tasks/main_menu_state_machine.md y tasks/ESTATUS.md.
+                // FIGHT_LOAD/IN_FIGHT todavía no tienen los offsets de "tipo de combate" (CPU vs CPU /
+                // jugador vs CPU / 2 jugadores) identificados -> ver el bloque [fightprobe] más abajo,
+                // que es el que junta la evidencia para poder completar este switch.
+                if (const uint8_t *rd = m_memory.getRDRAM())
+                {
+                    auto r32safe = [&](uint32_t addr) -> uint32_t {
+                        uint32_t v = 0xffffffffu;
+                        std::memcpy(&v, rd + (addr & PS2_RAM_MASK), 4);
+                        return v;
+                    };
+                    auto hex32 = [](uint32_t v) -> std::string {
+                        std::ostringstream o; o << "0x" << std::hex << v; return o.str();
+                    };
+
+                    std::string phase = "UNKNOWN";
+                    std::string sub;
+
+                    switch (bt3State)
+                    {
+                    case 0x01u:
+                    {
+                        phase = "BOOT";
+                        extern std::atomic<uint32_t> g_ps2FmvActive; // [hstate] definido en ps2_gs_gpu.cpp
+                        const bool fmv = g_ps2FmvActive.load(std::memory_order_relaxed) != 0u;
+                        const ps2_stubs::MemoryCardDebugSnapshot mc = ps2_stubs::getMemoryCardDebugSnapshot();
+                        // Heurística best-effort: refinar una vez que tengamos logs reales de un boot
+                        // completo (memcard aparece antes de que exista introTimer > 0).
+                        if (!mc.openFiles.empty())
+                            sub = "MEMCARD_LOAD(openFiles=" + std::to_string(mc.openFiles.size())
+                                + ",lastCmd=" + hex32(mc.lastCmd) + ")";
+                        else if (mc.lastCmd != 0)
+                            sub = "MEMCARD_CHECK(lastCmd=" + hex32(mc.lastCmd)
+                                + ",lastResult=" + std::to_string(mc.lastResult) + ")";
+                        else if (fmv)
+                            sub = "INTRO_FMV";
+                        else if (s_introTimer > 0)
+                            sub = "TITLE_SPLASH(timer=" + std::to_string(s_introTimer) + "/1800)";
+                        else
+                            sub = "SPLASH_LOGOS(sin marcador exacto todavia)";
+                        break;
+                    }
+                    case 0x04u:
+                    {
+                        phase = "MENU";
+                        const uint32_t mainStruct = r32safe(0x3B38D8u);
+                        if (mainStruct != 0u && mainStruct != 0xffffffffu)
+                        {
+                            const uint32_t globalFlags = r32safe(mainStruct + 0x3BCu);
+                            const bool submenu = (globalFlags & 0x08u) != 0u;
+                            const uint32_t subStruct = r32safe(mainStruct + 0x9A4u);
+                            const uint32_t menuState = (subStruct && subStruct != 0xffffffffu)
+                                ? r32safe(subStruct + 0x40u) : 0xffffffffu;
+                            // Cursor/selección/estado del item activo: *(0x3B38E8)+0x12C/0x138/0x13C
+                            // (offsets documentados en tasks/ESTATUS.md y main_menu_state_machine.md).
+                            const uint32_t itemBase = r32safe(0x3B38E8u);
+                            int32_t cursor = -1, selection = -1; uint32_t itemState = 0xffffffffu;
+                            if (itemBase != 0u && itemBase != 0xffffffffu)
+                            {
+                                cursor    = static_cast<int32_t>(r32safe(itemBase + 0x12Cu));
+                                selection = static_cast<int32_t>(r32safe(itemBase + 0x138u));
+                                itemState = r32safe(itemBase + 0x13Cu);
+                            }
+                            static const char *kItemStateNames[9] = {
+                                "PLATE_LOAD", "SECOND_PASS", "REFERENCE_COUNTER", "ANIMATION",
+                                "CONFIRM_ACCEPT", "NAVIGATION", "CHARACTER_SELECT", "VISUAL_RENDER",
+                                "FINAL_CONFIRM"
+                            };
+                            std::ostringstream o;
+                            o << (menuState == 9u ? "DISPLAYED" : menuState == 10u ? "TRANSITIONING" : "STATE?");
+                            o << (submenu ? "/SUBMENU" : "/ROOT");
+                            o << " cursor=" << cursor << " sel=" << selection << " itemState=";
+                            if (itemState < 9u) o << kItemStateNames[itemState];
+                            else o << hex32(itemState);
+                            sub = o.str();
+                        }
+                        else sub = "mainStruct=0 (menu aun no inicializado)";
+                        break;
+                    }
+                    case 0x06u: phase = "LOADING"; break;
+                    case 0x26u: case 0x28u: case 0x29u:
+                        phase = "PREFIGHT_SETUP"; sub = "raw=" + hex32(bt3State); break;
+                    case 0x27u: phase = "FIGHT_LOAD"; sub = "modo=? (ver [fightprobe])"; break;
+                    case 0x2Du: phase = "IN_FIGHT";   sub = "modo=? (ver [fightprobe])"; break;
+                    case 0x38u: phase = "POST_FIGHT"; break;
+                    default: break;
+                    }
+
+                    std::cerr << "[hstate] phase=" << phase << " sub=" << sub
+                              << " raw=" << hex32(bt3State) << std::endl;
+                }
+                // ===================== [fightprobe] Diagnóstico de tipo de combate =====================
+                // PS2X_FIGHTPROBE=1: en cada transición de bt3state hacia 0x26/0x27/0x2D vuelca:
+                //  (a) qué puertos de pad están siendo efectivamente leídos (readCount creciendo)
+                //      -> distingue CPU vs CPU (ningún puerto avanza) de P1 vs CPU (solo puerto 0)
+                //      de P1 vs P2 local (puertos 0 y 1).
+                //  (b) un hexdump de la región 0x3C00-0x3D00 del main-struct del menú (selección de
+                //      personaje/escenario/dificultad que se hizo en 0x04 antes de entrar a la pelea).
+                // Correr 3 veces (CPU-CPU, jugador-CPU, jugador-jugador local) y diffear las líneas
+                // [fightprobe] pegadas: el/los bytes que cambien de forma consistente entre corridas
+                // son el flag de "tipo de control" que hoy no está identificado.
+                {
+                    static const bool s_fightProbeOn = [](){
+                        const char *v = std::getenv("PS2X_FIGHTPROBE"); return v && v[0] && v[0] != '0';
+                    }();
+                    static uint32_t s_lastProbedState = 0xffffffffu;
+                    if (s_fightProbeOn && (bt3State == 0x26u || bt3State == 0x27u || bt3State == 0x2Du)
+                        && bt3State != s_lastProbedState)
+                    {
+                        s_lastProbedState = bt3State;
+                        const ps2_stubs::PadDebugSnapshot pad = ps2_stubs::getPadDebugSnapshot();
+                        std::ostringstream o;
+                        o << "[fightprobe] onEnter=0x" << std::hex << bt3State << std::dec;
+                        for (size_t port = 0; port < ps2_stubs::kPadDebugPortCount; ++port)
+                        {
+                            const ps2_stubs::PadDebugPortSnapshot &p = pad.ports[port][0];
+                            o << " port" << port << "(open=" << (p.open ? 1 : 0)
+                              << ",reads=" << p.readCount
+                              << ",lastBtn=0x" << std::hex << p.lastButtons << std::dec << ")";
+                        }
+                        if (const uint8_t *rd2 = m_memory.getRDRAM())
+                        {
+                            auto r32b = [&](uint32_t addr) -> uint32_t {
+                                uint32_t v = 0; std::memcpy(&v, rd2 + (addr & PS2_RAM_MASK), 4); return v;
+                            };
+                            const uint32_t mainStruct = r32b(0x3B38D8u);
+                            o << " mainStruct=0x" << std::hex << mainStruct << std::dec;
+                            if (mainStruct)
+                            {
+                                o << " selectRegion[0x3C00:0x3D00)=";
+                                for (uint32_t off = 0x3C00u; off < 0x3D00u; off += 4u)
+                                    o << ' ' << std::hex << std::setw(8) << std::setfill('0') << r32b(mainStruct + off);
+                                o << std::dec;
+                            }
+                        }
+                        std::cerr << o.str() << std::endl;
+                    }
+                }
+                // ===================== [menuhex] Estado del main menu =====================
+                // PS2X_MENUHEX=1: sondea TODOS los estados (0x04 root, 0x3e OPTIONS, 0x2c etc).
+                // vuelca cada vez que cambia el estado del menu.
+                //   mainPtr   = *(0x2FF10C)      (main game-state struct, ya usada por hstate)
+                //     +0x18   = screen_state_id  (bt3State)
+                //     +0x2C   = selected_entry_ID (la entry actualmente seleccionada)
+                //     +0x148  = cursor (indice en la lista de entries, 0-9)
+                //     +0x14   = visibility_flags (bit 6 = menu visible)
+                //     +0x68C  = transition_flags
+                //   dispPtr   = *(0x2FF28C)
+                //     +0x08   = display_filter (0-127)
+                //     +0xA0C  = frame_counter (0-24)
+                // Mas las jump tables fijas de overlay (ya confirmadas legibles):
+                //   0x3B4290 jumpTable (10 handlers), 0x3B42C0 dispatch2 (5 handlers).
+                {
+                    static const bool s_menuHexOn = [](){
+                        const char *v = std::getenv("PS2X_MENUHEX"); return v && v[0] && v[0] != '0';
+                    }();
+                    static std::string s_menuHexLastKey;   // fingerprint del ultimo estado volcado
+                    if (s_menuHexOn)
+                    {
+                        if (const uint8_t *rd3 = m_memory.getRDRAM())
+                        {
+                            auto r32m = [&](uint32_t addr) -> uint32_t {
+                                uint32_t v = 0; std::memcpy(&v, rd3 + (addr & PS2_RAM_MASK), 4); return v;
+                            };
+                            const uint32_t mainPtr = r32m(0x2FF10Cu);
+                            if (mainPtr == 0u || mainPtr == 0xffffffffu)
+                            {
+                                s_menuHexLastKey.clear();   // aun no inicializado: resetear fingerprint
+                            }
+                            else
+                            {
+                                const uint32_t dispPtr = r32m(0x2FF28Cu);
+                                const uint32_t screenState = r32m(mainPtr + 0x18u);
+                                const uint32_t selectedEntry = r32m(mainPtr + 0x2Cu);
+                                const uint32_t cursor = r32m(mainPtr + 0x148u);
+                                const uint32_t visibility = r32m(mainPtr + 0x14u);
+                                const uint32_t transition = r32m(mainPtr + 0x68Cu);
+                                const uint32_t dispFilter = (dispPtr && dispPtr != 0xffffffffu)
+                                    ? r32m(dispPtr + 0x08u) : 0xffffffffu;
+                                const uint32_t frameCtr = (dispPtr && dispPtr != 0xffffffffu)
+                                    ? r32m(dispPtr + 0xA0Cu) : 0xffffffffu;
+
+                                std::ostringstream kk;
+                                kk << std::hex << mainPtr << '/' << screenState << '/' << selectedEntry << '/'
+                                   << std::dec << static_cast<int32_t>(cursor) << '/' << transition;
+                                const std::string key = kk.str();
+                                if (key != s_menuHexLastKey)
+                                {
+                                    s_menuHexLastKey = key;
+                                    std::ostringstream m;
+                                    m << "[menuhex] mainPtr=0x" << std::hex << mainPtr
+                                      << " dispPtr=0x" << dispPtr << std::dec;
+                                    m << " screen=0x" << std::hex << screenState
+                                      << " selEntry=" << selectedEntry << std::dec
+                                      << " cursor=" << static_cast<int32_t>(cursor)
+                                      << " vis=0x" << std::hex << visibility
+                                      << " trans=0x" << transition << std::dec
+                                      << " dispFilter=" << (dispFilter == 0xffffffffu ? -1 : (int)(dispFilter & 0x7Fu))
+                                      << " frame=" << frameCtr;
+                                    std::cerr << m.str() << std::endl;
+
+                                    // "caption" deducida: selEntry -> nombre de entry (10 entries)
+                                    static const char *kEntryNames[10] = {
+                                        "DRAGON_ROAD", "ULTIMATE_BATTLE", "WORLD_TOURNAMENT", "DUEL", "DRAGON_NET",
+                                        "EVOLUCION_Z", "ENTRENAMIENTO", "DATA_CENTER", "REF_PERSONAJES", "OPCIONES"
+                                    };
+                                    const int32_t cur = static_cast<int32_t>(selectedEntry);
+                                    if (cur >= 0 && cur < 10)
+                                    {
+                                    std::cerr << "[menuhex] selEntry=" << cur
+                                              << " -> " << kEntryNames[cur] << std::endl;
+                                    }
+                                    else
+                                    {
+                                    std::cerr << "[menuhex] selEntry=" << cur
+                                              << " (fuera de rango 0-9, indice de submenu?)" << std::endl;
+                                    }
+
+                                    // (b) Item state jump table (10 handlers)
+                                    {
+                                        std::ostringstream j;
+                                        j << "[menuhex] jumpTable[0x3B4290]:";
+                                        for (uint32_t a = 0x3B4290u; a < 0x3B42B8u; a += 4u)
+                                            j << ' ' << std::hex << std::setw(8) << std::setfill('0') << r32m(a);
+                                        std::cerr << j.str() << std::dec << std::endl;
+                                    }
+
+                                    // (c) Second dispatch table (5 handlers)
+                                    {
+                                        std::ostringstream d;
+                                        d << "[menuhex] dispatch2[0x3B42C0]:";
+                                        for (uint32_t a = 0x3B42C0u; a < 0x3B42D4u; a += 4u)
+                                            d << ' ' << std::hex << std::setw(8) << std::setfill('0') << r32m(a);
+                                        std::cerr << d.str() << std::dec << std::endl;
+                                    }
+
+                                    // (d) seleccion de la struct principal: ventana +0x00..+0x30 y +0x140..+0x150
+                                    {
+                                        std::ostringstream n;
+                                        n << "[menuhex] mainPtr+0x00:";
+                                        for (uint32_t off = 0x00u; off < 0x34u; off += 4u)
+                                            n << ' ' << std::hex << std::setw(8) << std::setfill('0') << r32m(mainPtr + off);
+                                        n << " | +0x140:";
+                                        for (uint32_t off = 0x140u; off < 0x150u; off += 4u)
+                                            n << ' ' << std::hex << std::setw(8) << std::setfill('0') << r32m(mainPtr + off);
+                                        std::cerr << n.str() << std::dec << std::endl;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 // Scheduler-state dump (when PS2X_SCHED on): shows the deadlock -- which tid holds
                 // the token (m_schedCurrent) and each thread's present/blocked/order/pc.
                 if (m_schedEnabled)
@@ -4599,6 +5041,11 @@ void PS2Runtime::run()
 
     requestStop();
     if (GsGpuRenderer::enabled()) ps2GpuRenderer().abortBlockingBarriers();   // [barblock]
+
+#ifdef __linux__
+    keepStop.store(true, std::memory_order_relaxed);
+    if (pinKeeper.joinable()) pinKeeper.join();
+#endif
 
     const auto joinDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
     while (!gameThreadFinished.load(std::memory_order_acquire) &&


### PR DESCRIPTION
Contiene 2 commits de RexxColder:

1. **perf: raylib batch 16k elements + 512 drawcalls; drop pointless glFinish on texture unload** — sube RL_DEFAULT_BATCH_BUFFER_ELEMENTS 8192->16384 y RL_DEFAULT_BATCH_DRAWCALLS 256->512 en config.h de raylib vía CMakeLists (bloque tras re-aplicación del patch ps2x), y reemplaza glFinish() por glFlush() en UnloadTexture (driver-refcounted). Resultado: 30fps estables, host headroom 35-59, flush_ms/s 44-78.

2. **feat: reveal hidden Dragon Net Battle menu entry + AFS hex logging** — apply_overlay_patches.py (skip index 0xFF en 0x335568, gated PS2X_REVEAL_HIDDEN_MENU_ENTRY), setup.py tras gen_overlay, hex logging para AFS CD reads + docs de investigación.