### PR TITLE
feat: install wizard, folder-backed AFS & so much more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ ps2xRuntime/include/ps2_overlay_functions.h
 # Extracted game data + generated sources produced by games/bt3/setup.py. Never commit: it is the
 # user's own ripped disc content, and it is gigabytes.
 games/bt3/work
+
+# local build/deploy scratch
+log.txt
+__pycache__/

--- a/build_and_deploy.sh
+++ b/build_and_deploy.sh
@@ -14,11 +14,15 @@ set -euo pipefail
 # ---- config ---------------------------------------------------------------------
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ISO_DEFAULT="/home/rexx/Descargas/Roms/PS2/DragonBall Z - Budokai Tenkaichi 3.iso"
-DEPLOY_SRC="${BT3_DEPLOY_SRC:-/tmp/opencode/bt3-deploy}"   # holds stub.c + zstd source
-STUB_SRC="$DEPLOY_SRC/stub.c"
+DEPLOY_SRC="${BT3_DEPLOY_SRC:-/tmp/opencode/bt3-deploy}"   # scratch dir for zstd source + staged payload
 STUB_BIN="$DEPLOY_SRC/stub"
-ZSTD_DIR="$DEPLOY_SRC/zstd-1.5.7"
+ZSTD_VERSION="1.5.7"
+ZSTD_DIR="$DEPLOY_SRC/zstd-$ZSTD_VERSION"
 ZSTD_LIB="$ZSTD_DIR/lib/libzstd.a"
+# The stub source is kept in-repo (tools/selfx/stub.c) so the deploy survives
+# /tmp cleanup; an older BT3_DEPLOY_SRC copy still works as a fallback.
+STUB_SRC="${BT3_STUB_SRC:-$ROOT/tools/selfx/stub.c}"
+[ ! -f "$STUB_SRC" ] && STUB_SRC="$DEPLOY_SRC/stub.c"
 STAGE="$DEPLOY_SRC/stage"
 JOBS="${BT3_JOBS:-$(nproc)}"
 GAME="Dragon Ball - Budokai Tenkaichi 3"
@@ -68,9 +72,16 @@ if [[ ! -x "$STUB_BIN" ]]; then
     echo "== building static stub launcher"
     if [[ ! -f "$ZSTD_LIB" ]]; then
         if [[ ! -f "$ZSTD_DIR/Makefile" ]]; then
-            echo "ERROR: zstd source not found at $ZSTD_DIR (BT3_DEPLOY_SRC)"
-
-            exit 2
+            echo "== fetching zstd $ZSTD_VERSION source"
+            mkdir -p "$DEPLOY_SRC"
+            if ! curl -fsSL --retry 2 \
+                "https://github.com/facebook/zstd/releases/download/v$ZSTD_VERSION/zstd-$ZSTD_VERSION.tar.gz" \
+                -o "$DEPLOY_SRC/zstd.tar.gz"; then
+                echo "ERROR: could not fetch zstd $ZSTD_VERSION (BT3_DEPLOY_SRC=$DEPLOY_SRC)"
+                exit 2
+            fi
+            tar -xzf "$DEPLOY_SRC/zstd.tar.gz" -C "$DEPLOY_SRC"
+            rm -f "$DEPLOY_SRC/zstd.tar.gz"
         fi
         make -C "$ZSTD_DIR" -j"$JOBS" lib-release > /dev/null
     fi

--- a/ps2xRuntime/include/ps2_settings_overlay.h
+++ b/ps2xRuntime/include/ps2_settings_overlay.h
@@ -17,7 +17,7 @@ public:
         float masterVolume = 1.0f;
         float musicVolume = 1.0f;
         float sfxVolume = 1.0f;
-        bool gpuRenderer = false;
+        bool gpuRenderer = true;
         bool glow = true;
         bool postfx = false;
         bool glowFix = true;   // [glowfix] BT3's bloom/glow chain (Kaioken aura); applies on restart
@@ -48,6 +48,8 @@ public:
         // 2=+ftspike+fightprobe+reveal, 3=+frameprof+camprobe. Drives which PS2X_* env vars
         // main() exports; stderr is redirected to <deploy>/logs/bt3.log on any level > 0.
         int logLevel = 1;
+
+        bool operator==(const Settings &o) const;
     };
 
     static bool isWidescreen() { return s_widescreen; }
@@ -81,6 +83,7 @@ private:
     bool m_initialized = false;
     bool m_dirty = false;
     Settings m_settings;
+    Settings m_settingsAtBoot;
     std::string m_configPath;
     int m_activeTab = 0;
 

--- a/ps2xRuntime/src/launcher/afs_archive.cpp
+++ b/ps2xRuntime/src/launcher/afs_archive.cpp
@@ -1,0 +1,260 @@
+#include "afs_archive.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <vector>
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+constexpr char kAfsMagic[4] = {'A', 'F', 'S', 0};
+constexpr char kIdxMagic[8] = {'D', 'B', 'Z', 'A', 'F', 'S', '0', '1'};
+
+enum Type : uint32_t
+{
+    T_OTHER = 0,
+    T_MODEL = 1,
+    T_ANIM = 2,
+    T_EFF = 3,
+    T_PAK1 = 4,
+    T_PAK3 = 5,
+    T_Q1 = 6,
+    T_S12C = 7,
+    T_R19 = 8,
+    T_GS = 9,
+    T_PAK2 = 10,
+};
+
+uint32_t classify(const uint8_t *head, uint32_t avail)
+{
+    if (avail < 8)
+        return T_OTHER;
+    uint32_t w0, w1;
+    std::memcpy(&w0, head, 4);
+    std::memcpy(&w1, head + 4, 4);
+    if (w0 == 0xFC && w1 == 0x400) return T_MODEL;
+    if (w0 == 0x1B8 && w1 == 0x700) return T_ANIM;
+    if (w0 == 0x6 && w1 == 0x40) return T_EFF;
+    if (w0 == 0x1 && w1 == 0x40) return T_PAK1;
+    if (w0 == 0x3 && w1 == 0x40) return T_PAK3;
+    if (w0 == 0x1 && w1 == 0x8) return T_Q1;
+    if (w0 == 0x12C && w1 == 0x4C0) return T_S12C;
+    if (w0 == 0x19 && w1 == 0x80) return T_R19;
+    if (w0 == 0x435347) return T_GS;
+    if (w0 == 0x2 && w1 == 0x40) return T_PAK2;
+    return T_OTHER;
+}
+
+struct Entry
+{
+    uint32_t off = 0;
+    uint32_t size = 0;
+    uint32_t type = 0;
+};
+
+struct Slot
+{
+    Entry en;
+    uint32_t slotBytes = 0;
+};
+
+bool readFile(const fs::path &p, std::vector<uint8_t> &out)
+{
+    std::FILE *f = std::fopen(p.string().c_str(), "rb");
+    if (!f)
+        return false;
+    std::fseek(f, 0, SEEK_END);
+    long sz = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    if (sz < 0)
+    {
+        std::fclose(f);
+        return false;
+    }
+    out.resize(static_cast<size_t>(sz));
+    if (sz > 0 && std::fread(out.data(), 1, static_cast<size_t>(sz), f) != static_cast<size_t>(sz))
+    {
+        std::fclose(f);
+        return false;
+    }
+    std::fclose(f);
+    return true;
+}
+
+bool parseAfs(const fs::path &p, std::vector<Entry> &entries)
+{
+    std::vector<uint8_t> data;
+    if (!readFile(p, data))
+        return false;
+    if (data.size() < 8)
+        return false;
+    uint32_t magic = 0;
+    std::memcpy(&magic, data.data(), 4);
+    if (std::memcmp(&magic, kAfsMagic, 4) != 0)
+        return false;
+    uint32_t count = 0;
+    std::memcpy(&count, data.data() + 4, 4);
+    if (data.size() < 8ull + count * 8ull)
+        return false;
+
+    entries.clear();
+    entries.reserve(count);
+    for (uint32_t i = 0; i < count; ++i)
+    {
+        uint32_t off, sz;
+        std::memcpy(&off, data.data() + 8 + i * 8, 4);
+        std::memcpy(&sz, data.data() + 8 + i * 8 + 4, 4);
+        uint32_t type = T_OTHER;
+        if (static_cast<uint64_t>(off) + 8 <= data.size())
+            type = classify(data.data() + off, std::min<uint32_t>(sz, 8));
+        entries.push_back({off, sz, type});
+    }
+    return true;
+}
+
+std::vector<Slot> computeSlots(const std::vector<Entry> &rows, uint32_t afsBytes,
+                               uint32_t &outDataStart)
+{
+    std::vector<Slot> slots;
+    outDataStart = afsBytes;
+    for (const auto &en : rows)
+        if (en.size > 0 && en.off < outDataStart)
+            outDataStart = en.off;
+    for (const auto &en : rows)
+    {
+        if (en.size == 0) // skip sentinel / empty rows
+            continue;
+        uint32_t nextOff = afsBytes;
+        for (const auto &o : rows)
+            if (o.off > en.off && o.off < nextOff)
+                nextOff = o.off;
+        if (en.off >= nextOff)
+            nextOff = std::min<uint32_t>(en.off + en.size, afsBytes);
+        if (en.off > afsBytes)
+            continue;
+        slots.push_back({en, nextOff - en.off});
+    }
+    std::sort(slots.begin(), slots.end(),
+              [](const Slot &a, const Slot &b) { return a.en.off < b.en.off; });
+    return slots;
+}
+
+void writeU32(std::vector<uint8_t> &out, uint32_t v)
+{
+    out.push_back(static_cast<uint8_t>(v));
+    out.push_back(static_cast<uint8_t>(v >> 8));
+    out.push_back(static_cast<uint8_t>(v >> 16));
+    out.push_back(static_cast<uint8_t>(v >> 24));
+}
+
+} // namespace
+
+AfsConvertResult convertAfsToFolder(const std::string &afsPath, const std::string &outDir,
+                                    const std::function<void(const std::string &)> &onStatus,
+                                    const std::function<void(uint64_t, uint64_t)> &onProgress)
+{
+    using namespace std::literals;
+
+    auto fail = [](std::string msg) { return AfsConvertResult{false, std::move(msg)}; };
+
+    const fs::path src(afsPath);
+    const fs::path base = src.filename().stem();
+
+    std::vector<Entry> entries;
+    if (!parseAfs(src, entries))
+        return fail("cannot read " + src.string() + " as an AFS container");
+
+    std::error_code ec;
+    fs::path dir = fs::path(outDir) / base.string();
+    fs::create_directories(dir, ec);
+    if (ec)
+        return fail("cannot create " + dir.string());
+    if (onStatus)
+        onStatus("reading " + base.string() + " index");
+
+    std::vector<uint8_t> afs;
+    if (!readFile(src, afs))
+        return fail("cannot read " + src.string());
+    if (afs.size() > UINT32_MAX)
+        return fail(src.string() + " too large for the index");
+    const uint32_t afsBytes = static_cast<uint32_t>(afs.size());
+
+    uint32_t dataStart = 0;
+    std::vector<Slot> slots = computeSlots(entries, afsBytes, dataStart);
+    const uint64_t total = 2ull * afsBytes;
+    uint64_t done = 0;
+
+    // Slot files: exact physical slices [off, nextOff), padding preserved.
+    if (onStatus)
+        onStatus("extracting " + base.string() + " entries (" +
+                 std::to_string(slots.size()) + " slots)");
+    for (size_t i = 0; i < slots.size(); ++i)
+    {
+        const Slot &s = slots[i];
+        if (static_cast<uint64_t>(s.en.off) + s.slotBytes > afs.size())
+            return fail("entry out of range in " + src.string());
+        char name[32];
+        std::snprintf(name, sizeof(name), "%06zu", i);
+        std::FILE *f = std::fopen((dir / name).string().c_str(), "wb");
+        if (!f)
+            return fail("cannot write " + (dir / name).string());
+        const size_t written = std::fwrite(afs.data() + s.en.off, 1, s.slotBytes, f);
+        std::fclose(f);
+        if (written != s.slotBytes)
+            return fail("short write " + (dir / name).string());
+        done += s.slotBytes;
+        if (onProgress)
+            onProgress(done, total);
+    }
+
+    // Index blob + slot table (idx v2), byte-exact reassembly contract.
+    std::vector<uint8_t> idx;
+    idx.insert(idx.end(), kIdxMagic, kIdxMagic + 8);
+    writeU32(idx, 2u);
+    writeU32(idx, static_cast<uint32_t>(slots.size()));
+    writeU32(idx, afsBytes);
+    writeU32(idx, dataStart);
+    for (const auto &s : slots)
+    {
+        writeU32(idx, s.en.off);
+        writeU32(idx, s.en.size);
+        writeU32(idx, s.slotBytes);
+        writeU32(idx, s.en.type);
+    }
+    idx.insert(idx.end(), afs.begin(), afs.begin() + dataStart);
+
+    const fs::path idxPath = fs::path(outDir) / (base.string() + ".idx");
+    {
+        std::FILE *f = std::fopen(idxPath.string().c_str(), "wb");
+        if (!f)
+            return fail("cannot write " + idxPath.string());
+        const bool ok = std::fwrite(idx.data(), 1, idx.size(), f) == idx.size();
+        std::fclose(f);
+        if (!ok)
+            return fail("short write " + idxPath.string());
+    }
+
+    // Byte-for-byte verification before the caller drops the source .AFS.
+    if (onStatus)
+        onStatus("verifying " + base.string());
+    for (size_t i = 0; i < slots.size(); ++i)
+    {
+        const Slot &s = slots[i];
+        char name[32];
+        std::snprintf(name, sizeof(name), "%06zu", i);
+        std::vector<uint8_t> got;
+        if (!readFile(dir / name, got) || got.size() != s.slotBytes ||
+            std::memcmp(got.data(), afs.data() + s.en.off, s.slotBytes) != 0)
+            return fail("verification mismatch at slot " + std::to_string(i) + " of " +
+                        src.string());
+        done += s.slotBytes;
+        if (onProgress)
+            onProgress(done, total);
+    }
+
+    return AfsConvertResult{true, std::string()};
+}

--- a/ps2xRuntime/src/launcher/afs_archive.h
+++ b/ps2xRuntime/src/launcher/afs_archive.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+struct AfsConvertResult
+{
+    bool ok = false;
+    std::string error;
+};
+
+// Extracts one Dragon Ball: BT3 AFS container (PZS3US*.AFS) into the physical
+// slot layout that the runtime serves from folders:
+//   <outDir>/<stem>/000000, 000001, ...   slot files (exact disk slices)
+//   <outDir>/<stem>.idx                   v2 index (blob + slot table)
+// After dumping it re-reads every slot file and byte-compares it against the
+// source so the caller can safely drop the .AFS afterwards.
+//
+// onStatus receives a short human-readable stage ("reading index...",
+// "extracting entries...", "verifying..."); onProgress receives accumulated
+// done/total bytes where total == 2 * fileSize (one pass to write the slots,
+// one pass to verify them), or no progress row written when serializing.
+AfsConvertResult convertAfsToFolder(
+    const std::string &afsPath, const std::string &outDir,
+    const std::function<void(const std::string &)> &onStatus = {},
+    const std::function<void(uint64_t done, uint64_t total)> &onProgress = {});

--- a/ps2xRuntime/src/launcher/afs_extract_worker.cpp
+++ b/ps2xRuntime/src/launcher/afs_extract_worker.cpp
@@ -1,0 +1,59 @@
+#include "afs_extract_worker.h"
+
+#include "afs_archive.h"
+
+#include <QFile>
+#include <QFileInfo>
+
+void AfsExtractWorker::doWork(const QStringList &afsFiles)
+{
+    qint64 totalBytes = 0;
+    for (const QString &f : afsFiles)
+        totalBytes += 2 * QFileInfo(f).size(); // one pass writes the slots, one verifies
+    if (totalBytes <= 0)
+    {
+        emit done(false, QStringLiteral("No AFS containers to convert."));
+        return;
+    }
+
+    const qint64 tickBytes = qMax<qint64>(256 * 1024, totalBytes / 1000); // ~0.1% UI throttle
+
+    qint64 base = 0;
+    for (const QString &f : afsFiles)
+    {
+        const QFileInfo info(f);
+        const qint64 fileTotal = 2 * info.size();
+        qint64 last = base;
+
+        emit status(QStringLiteral("Converting %1…").arg(info.fileName()));
+
+        const auto onStatus = [this](const std::string &s) {
+            emit status(QString::fromStdString(s));
+        };
+        const auto onProgress = [this, &last, tickBytes, totalBytes, base](uint64_t d, uint64_t) {
+            const qint64 cur = base + static_cast<qint64>(d);
+            if (cur - last >= tickBytes)
+            {
+                last = cur;
+                emit progress(cur, totalBytes);
+            }
+        };
+
+        const AfsConvertResult r = convertAfsToFolder(
+            f.toStdString(), info.absolutePath().toStdString(), onStatus, onProgress);
+
+        if (!r.ok)
+        {
+            emit progress(totalBytes, totalBytes);
+            emit done(false, QString::fromStdString(r.error));
+            return;
+        }
+
+        base += fileTotal;
+        emit status(QStringLiteral("Removing %1…").arg(info.fileName()));
+        QFile::remove(f);
+        emit progress(base, totalBytes);
+    }
+
+    emit done(true, QString());
+}

--- a/ps2xRuntime/src/launcher/afs_extract_worker.h
+++ b/ps2xRuntime/src/launcher/afs_extract_worker.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <QObject>
+#include <QStringList>
+
+// Converts every PZS3US*.AFS next to a data/ directory into folder slots +
+// .idx and removes the source. Runs on a worker thread so the UI keeps
+// painting the live progress; status() carries the "what am I doing right
+// now" line shown under the progress bar.
+class AfsExtractWorker : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+public slots:
+    void doWork(const QStringList &afsFiles);
+
+signals:
+    void status(const QString &text);
+    void progress(qint64 done, qint64 total);
+    void done(bool ok, const QString &msg);
+};

--- a/ps2xRuntime/src/launcher/extract_worker.cpp
+++ b/ps2xRuntime/src/launcher/extract_worker.cpp
@@ -1,0 +1,76 @@
+#include "extract_worker.h"
+
+#include "iso9660.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+
+void ExtractWorker::doWork(const QString &isoPath, const QString &dataDir)
+{
+    QDir d(dataDir);
+    if (d.exists())
+        d.removeRecursively();
+    if (!QDir().mkpath(dataDir))
+    {
+        emit done(false, QStringLiteral("Failed to create the game data folder."));
+        return;
+    }
+
+    Iso9660 iso;
+    if (!iso.open(isoPath))
+    {
+        emit done(false, iso.error());
+        return;
+    }
+
+    quint64 total = 0;
+    const QList<Iso9660::File> &files = iso.files();
+    for (const Iso9660::File &f : files)
+    {
+        if (!f.dir)
+            total += f.size();
+    }
+
+    quint64 doneBytes = 0;
+    for (const Iso9660::File &f : files)
+    {
+        if (f.dir)
+            continue;
+        const QString dest = dataDir + QLatin1Char('/') + f.path;
+        const QFileInfo fi(dest);
+        if (!QDir().mkpath(fi.absolutePath()))
+        {
+            emit done(false, QStringLiteral("Failed to create %1").arg(fi.absolutePath()));
+            return;
+        }
+        QFile out(dest);
+        if (!out.open(QIODevice::WriteOnly))
+        {
+            emit done(false, QStringLiteral("Failed to write %1").arg(dest));
+            return;
+        }
+        const qint64 got = iso.readFile(f, [&](const QByteArray &chunk) {
+            out.write(chunk);
+            doneBytes += static_cast<quint64>(chunk.size());
+            emit progress(static_cast<qint64>(doneBytes), static_cast<qint64>(total));
+        });
+        if (got < 0)
+        {
+            emit done(false, QStringLiteral("Failed to read %1 from the disc image").arg(f.path));
+            return;
+        }
+    }
+
+    // BIN/DBZP.BIN is opened read-write by the game; ISO extraction yields
+    // read-only files, so lift the write bits (mirrors setup.py make_writable).
+    const QString dbzp = QDir(dataDir).filePath(QStringLiteral("BIN/DBZP.BIN"));
+    if (QFile::exists(dbzp))
+    {
+        QFile::setPermissions(dbzp, QFileDevice::ReadOwner | QFileDevice::WriteOwner
+                                         | QFileDevice::ReadGroup | QFileDevice::WriteGroup
+                                         | QFileDevice::ReadOther | QFileDevice::WriteOther);
+    }
+
+    emit done(true, QString());
+}

--- a/ps2xRuntime/src/launcher/extract_worker.h
+++ b/ps2xRuntime/src/launcher/extract_worker.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+// Streams the validated disc image tree into the deployment data/ folder on a
+// worker thread so the UI keeps painting the progress bar.
+class ExtractWorker : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+public slots:
+    void doWork(const QString &isoPath, const QString &dataDir);
+
+signals:
+    void progress(qint64 done, qint64 total);
+    void done(bool ok, const QString &msg);
+};

--- a/ps2xRuntime/src/launcher/install_wizard_dialog.cpp
+++ b/ps2xRuntime/src/launcher/install_wizard_dialog.cpp
@@ -1,0 +1,430 @@
+#include "install_wizard_dialog.h"
+
+#include "extract_worker.h"
+#include "iso9660.h"
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileDialog>
+#include <QFileInfo>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QProcess>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QStackedWidget>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+#include <QThread>
+#include <QVBoxLayout>
+
+#include <utility>
+
+namespace
+{
+constexpr qint64 kMiB = 1024 * 1024;
+
+QString fmtMb(qint64 bytes)
+{
+    return QString::number(bytes / kMiB);
+}
+
+QString pickUnpacker()
+{
+    static const char *kTools[] = {"7zz", "7z", "unrar", "bsdtar", "tar"};
+    for (const char *t : kTools)
+    {
+        const QString tool = QLatin1String(t);
+        if (!QStandardPaths::findExecutable(tool).isEmpty())
+            return tool;
+    }
+    return QString();
+}
+
+bool runUnpacker(const QString &tool, const QString &archive, const QString &dest, QString *err)
+{
+    QStringList args;
+    if (tool == QLatin1String("7zz") || tool == QLatin1String("7z"))
+        args = {QStringLiteral("x"), QStringLiteral("-y"), QStringLiteral("-o") + dest, archive};
+    else if (tool == QLatin1String("unrar"))
+        args = {QStringLiteral("x"), QStringLiteral("-y"), archive, dest + QLatin1Char('/')};
+    else if (tool == QLatin1String("bsdtar") || tool == QLatin1String("tar"))
+        args = {QStringLiteral("-xf"), archive, QStringLiteral("-C"), dest};
+    else
+    {
+        *err = QStringLiteral("The extraction failed. Please extract the ISO manually.");
+        return false;
+    }
+
+    QProcess p;
+    p.start(tool, args);
+    while (p.state() != QProcess::NotRunning)
+    {
+        if (!p.waitForFinished(50))
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+    }
+    if (p.exitStatus() != QProcess::NormalExit || p.exitCode() != 0)
+    {
+        *err = QStringLiteral("The extraction failed. Please extract the ISO manually.");
+        return false;
+    }
+    return true;
+}
+
+QString findImageRecursive(const QString &root, int depth)
+{
+    if (depth > 3)
+        return QString();
+    QDirIterator it(root, QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        it.next();
+        const QString n = it.fileName().toLower();
+        if (n.endsWith(QLatin1String(".iso")) || n.endsWith(QLatin1String(".img"))
+            || n.endsWith(QLatin1String(".bin")))
+            return it.filePath();
+    }
+    return QString();
+}
+
+} // namespace
+
+InstallWizardDialog::InstallWizardDialog(QWidget *parent, bool reinstall)
+    : QDialog(parent)
+{
+    setWindowTitle(QStringLiteral("Install Wizard"));
+    resize(520, 330);
+    setModal(true);
+    buildUi();
+    if (reinstall)
+        setIndex(1); // straight to the disc dump selection
+}
+
+InstallWizardDialog::~InstallWizardDialog()
+{
+    delete m_tmp;
+}
+
+void InstallWizardDialog::buildUi()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_stack = new QStackedWidget(this);
+    mainLayout->addWidget(m_stack);
+
+    // --- Page A: missing / corrupt data -------------------------------------
+    auto *pageA = new QWidget;
+    {
+        auto *l = new QVBoxLayout(pageA);
+        l->setContentsMargins(28, 24, 28, 24);
+        auto *head = new QLabel(QStringLiteral("Game Data file are missing or corrupted"), pageA);
+        head->setWordWrap(true);
+        head->setStyleSheet(QStringLiteral("font-size: 17px; font-weight: 600; color: #ffd9a0;"));
+        l->addWidget(head);
+        l->addSpacing(8);
+        auto *body = new QLabel(QStringLiteral("The game will need to reinstall game files."), pageA);
+        body->setWordWrap(true);
+        body->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+        l->addWidget(body);
+        l->addStretch(1);
+
+        auto *row = new QHBoxLayout;
+        row->addStretch(1);
+        m_nextMissing = new QPushButton(QStringLiteral("Next"), pageA);
+        m_nextMissing->setObjectName(QStringLiteral("wizardButton"));
+        m_nextMissing->setCursor(Qt::PointingHandCursor);
+        connect(m_nextMissing, &QPushButton::clicked, this, &InstallWizardDialog::onNextMissing);
+        row->addWidget(m_nextMissing);
+        l->addLayout(row);
+    }
+    m_stack->addWidget(pageA);
+
+    // --- Page B: locate + validate the disc dump -----------------------------
+    auto *pageB = new QWidget;
+    {
+        auto *l = new QVBoxLayout(pageB);
+        l->setContentsMargins(28, 24, 28, 24);
+        auto *head = new QLabel(QStringLiteral("Install game data"), pageB);
+        head->setStyleSheet(QStringLiteral("font-size: 17px; font-weight: 600; color: #ffd9a0;"));
+        l->addWidget(head);
+        l->addSpacing(8);
+
+        auto *prompt = new QLabel(
+            QStringLiteral("Please introduce the directory to your own game disc dump to install:"), pageB);
+        prompt->setWordWrap(true);
+        prompt->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+        l->addWidget(prompt);
+        l->addSpacing(10);
+
+        auto *row = new QHBoxLayout;
+        m_selected = new QLabel(QStringLiteral("No file selected"), pageB);
+        m_selected->setWordWrap(true);
+        m_selected->setStyleSheet(QStringLiteral("font-size: 12px; color: #8b93a3;"));
+        row->addWidget(m_selected, 1);
+        m_browse = new QPushButton(QStringLiteral("Browse…"), pageB);
+        m_browse->setObjectName(QStringLiteral("wizardButton"));
+        m_browse->setCursor(Qt::PointingHandCursor);
+        connect(m_browse, &QPushButton::clicked, this, &InstallWizardDialog::onBrowse);
+        row->addWidget(m_browse);
+        l->addLayout(row);
+        l->addSpacing(12);
+
+        auto *dots = new QHBoxLayout;
+        m_dot = new QLabel(QStringLiteral("●"), pageB);
+        m_dot->setStyleSheet(QStringLiteral("font-size: 15px; color: #8b93a3;"));
+        dots->addWidget(m_dot);
+        m_dotText = new QLabel(QStringLiteral("Awaiting a disc dump…"), pageB);
+        m_dotText->setWordWrap(true);
+        m_dotText->setStyleSheet(QStringLiteral("font-size: 13px; color: #8b93a3;"));
+        dots->addWidget(m_dotText, 1);
+        l->addLayout(dots);
+        l->addStretch(1);
+
+        auto *rowB = new QHBoxLayout;
+        rowB->addStretch(1);
+        m_retryDump = new QPushButton(QStringLiteral("Retry"), pageB);
+        m_retryDump->setObjectName(QStringLiteral("wizardButton"));
+        m_retryDump->setCursor(Qt::PointingHandCursor);
+        m_retryDump->setVisible(false);
+        connect(m_retryDump, &QPushButton::clicked, this, &InstallWizardDialog::onRetryDump);
+        rowB->addWidget(m_retryDump);
+        rowB->addSpacing(8);
+        m_nextDump = new QPushButton(QStringLiteral("Next"), pageB);
+        m_nextDump->setObjectName(QStringLiteral("wizardButton"));
+        m_nextDump->setCursor(Qt::PointingHandCursor);
+        m_nextDump->setEnabled(false);
+        connect(m_nextDump, &QPushButton::clicked, this, &InstallWizardDialog::onInstall);
+        rowB->addWidget(m_nextDump);
+        l->addLayout(rowB);
+    }
+    m_stack->addWidget(pageB);
+
+    // --- Page C: installation progress ---------------------------------------
+    auto *pageC = new QWidget;
+    {
+        auto *l = new QVBoxLayout(pageC);
+        l->setContentsMargins(28, 24, 28, 24);
+        auto *head = new QLabel(QStringLiteral("Installation in progress"), pageC);
+        head->setStyleSheet(QStringLiteral("font-size: 17px; font-weight: 600; color: #ffd9a0;"));
+        l->addWidget(head);
+        l->addSpacing(12);
+
+        m_progressText = new QLabel(QStringLiteral("0 MB / 0 MB"), pageC);
+        m_progressText->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+        l->addWidget(m_progressText);
+
+        m_bar = new QProgressBar(pageC);
+        m_bar->setRange(0, 1);
+        m_bar->setValue(0);
+        m_bar->setTextVisible(false);
+        m_bar->setStyleSheet(QStringLiteral(
+            "QProgressBar { background:#1b222b; border:1px solid #2a3542; border-radius:4px; height:14px; }"
+            "QProgressBar::chunk { background:#ff9e1a; border-radius:4px; }"));
+        l->addWidget(m_bar);
+        l->addSpacing(12);
+
+        m_doneLabel = new QLabel(QString(), pageC);
+        m_doneLabel->setWordWrap(true);
+        m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+        l->addWidget(m_doneLabel);
+        l->addStretch(1);
+
+        auto *rowC = new QHBoxLayout;
+        rowC->addStretch(1);
+        m_retryInstall = new QPushButton(QStringLiteral("Retry"), pageC);
+        m_retryInstall->setObjectName(QStringLiteral("wizardButton"));
+        m_retryInstall->setCursor(Qt::PointingHandCursor);
+        m_retryInstall->setVisible(false);
+        connect(m_retryInstall, &QPushButton::clicked, this, &InstallWizardDialog::onRetryInstall);
+        rowC->addWidget(m_retryInstall);
+        rowC->addSpacing(8);
+        m_close = new QPushButton(QStringLiteral("Close"), pageC);
+        m_close->setObjectName(QStringLiteral("wizardButton"));
+        m_close->setCursor(Qt::PointingHandCursor);
+        connect(m_close, &QPushButton::clicked, this, [this] {
+            if (m_installed)
+                accept();
+            else
+                reject();
+        });
+        rowC->addWidget(m_close);
+        l->addLayout(rowC);
+    }
+    m_stack->addWidget(pageC);
+}
+
+void InstallWizardDialog::setIndex(int index)
+{
+    if (index == 1)
+        m_retryDump->setVisible(false);
+    m_stack->setCurrentIndex(index);
+}
+
+void InstallWizardDialog::onNextMissing()
+{
+    setIndex(1);
+}
+
+void InstallWizardDialog::onBrowse()
+{
+    static const QString kFilter =
+        QStringLiteral("Game disc dump (*.iso *.img *.rar *.7z *.zip *.tar *.tar.gz);;All files (*)");
+    const QString path = QFileDialog::getOpenFileName(
+        this, QStringLiteral("Select your own game disc dump"), QDir::homePath(), kFilter);
+    if (path.isEmpty())
+        return;
+    m_selected->setText(QDir::toNativeSeparators(path));
+    attemptVerify(path);
+}
+
+void InstallWizardDialog::onRetryDump()
+{
+    attemptVerify(m_dumpPath);
+}
+
+void InstallWizardDialog::setVerified(bool ok, const QString &text)
+{
+    m_verified = ok;
+    m_dot->setStyleSheet(QStringLiteral("font-size: 15px; color: %1;")
+                             .arg(ok ? QStringLiteral("#22c55e") : QStringLiteral("#ef4444")));
+    m_dotText->setStyleSheet(QStringLiteral("font-size: 13px; color: %1;")
+                                 .arg(ok ? QStringLiteral("#22c55e") : QStringLiteral("#ef4444")));
+    m_dotText->setText(text);
+    m_nextDump->setEnabled(ok);
+}
+
+void InstallWizardDialog::attemptVerify(const QString &dumpPath)
+{
+    m_dumpPath = dumpPath;
+    m_retryDump->setVisible(false);
+    m_dot->setStyleSheet(QStringLiteral("font-size: 15px; color: #8b93a3;"));
+    m_dotText->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+    m_dotText->setText(QStringLiteral("Checking disc dump…"));
+    QCoreApplication::processEvents();
+
+    const QString lower = dumpPath.toLower();
+    const bool isImage = lower.endsWith(QLatin1String(".iso")) || lower.endsWith(QLatin1String(".img"));
+
+    if (!isImage)
+    {
+        if (!m_tmp)
+            m_tmp = new QTemporaryDir;
+        QString err;
+        m_isoPath = resolveInnerImage(dumpPath, &err);
+        if (m_isoPath.isEmpty())
+        {
+            setVerified(false, err);
+            m_retryDump->setVisible(true);
+            return;
+        }
+    }
+    else
+    {
+        m_isoPath = dumpPath;
+    }
+
+    if (DiscVerify::verifySlusFromIso(m_isoPath))
+        setVerified(true, QStringLiteral("Game Disc Validated"));
+    else
+        setVerified(false, QStringLiteral("Cannot verify game disc. Is it the right version?"));
+}
+
+QString InstallWizardDialog::resolveInnerImage(const QString &dumpPath, QString *err)
+{
+    const QString tool = pickUnpacker();
+    if (tool.isEmpty())
+    {
+        *err = QStringLiteral("The extraction failed. Please extract the ISO manually.");
+        return QString();
+    }
+
+    const QString unpackDir = m_tmp->path() + QStringLiteral("/unpack");
+    if (!QDir().mkpath(unpackDir))
+    {
+        *err = QStringLiteral("The extraction failed. Please extract the ISO manually.");
+        return QString();
+    }
+
+    if (!runUnpacker(tool, dumpPath, unpackDir, err))
+        return QString();
+
+    const QString image = findImageRecursive(unpackDir, 3);
+    if (image.isEmpty())
+        *err = QStringLiteral("The extraction failed. Please extract the ISO manually.");
+    return image;
+}
+
+void InstallWizardDialog::onInstall()
+{
+    if (!m_verified || m_isoPath.isEmpty())
+        return;
+    startExtraction();
+}
+
+void InstallWizardDialog::onRetryInstall()
+{
+    if (m_isoPath.isEmpty())
+    {
+        setIndex(1);
+        return;
+    }
+    startExtraction();
+}
+
+void InstallWizardDialog::startExtraction()
+{
+    m_bar->setRange(0, 1);
+    m_bar->setValue(0);
+    m_progressText->setText(QStringLiteral("0 MB / 0 MB"));
+    m_doneLabel->setText(QStringLiteral("Installation in progress…"));
+    m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+    m_retryInstall->setVisible(false);
+    m_close->setEnabled(false);
+    setIndex(2);
+    QCoreApplication::processEvents();
+
+    m_thread = new QThread;
+    m_worker = new ExtractWorker;
+    m_worker->moveToThread(m_thread);
+    connect(m_thread, &QThread::finished, m_worker, &QObject::deleteLater);
+    connect(m_thread, &QThread::finished, m_thread, &QObject::deleteLater);
+    connect(m_worker, &ExtractWorker::progress, this, &InstallWizardDialog::onExtractProgress);
+    connect(m_worker, &ExtractWorker::done, this, &InstallWizardDialog::onExtractDone);
+    connect(m_worker, &ExtractWorker::done, m_thread, &QThread::quit);
+    m_thread->start();
+
+    const QString dataDir = QApplication::applicationDirPath() + QStringLiteral("/data");
+    QMetaObject::invokeMethod(m_worker, "doWork", Qt::QueuedConnection, Q_ARG(QString, m_isoPath),
+                              Q_ARG(QString, dataDir));
+}
+
+void InstallWizardDialog::onExtractProgress(qint64 done, qint64 total)
+{
+    if (total > 0)
+        m_bar->setRange(0, static_cast<int>(total / (64 * 1024)));
+    m_bar->setValue(static_cast<int>(done / (64 * 1024)));
+    m_progressText->setText(
+        QStringLiteral("%1 MB / %2 MB").arg(fmtMb(done)).arg(fmtMb(total)));
+}
+
+void InstallWizardDialog::onExtractDone(bool ok, const QString &msg)
+{
+    if (ok)
+    {
+        m_installed = true;
+        m_doneLabel->setText(QStringLiteral("Installation complete. Game disc validated."));
+        m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #22c55e;"));
+        m_bar->setValue(m_bar->maximum());
+    }
+    else
+    {
+        m_doneLabel->setText(msg.isEmpty() ? QStringLiteral("Installation failed.") : msg);
+        m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #ef4444;"));
+        m_retryInstall->setVisible(true);
+    }
+    m_close->setEnabled(true);
+}

--- a/ps2xRuntime/src/launcher/install_wizard_dialog.cpp
+++ b/ps2xRuntime/src/launcher/install_wizard_dialog.cpp
@@ -1,5 +1,6 @@
 #include "install_wizard_dialog.h"
 
+#include "afs_extract_worker.h"
 #include "extract_worker.h"
 #include "iso9660.h"
 
@@ -88,6 +89,23 @@ QString findImageRecursive(const QString &root, int depth)
             return it.filePath();
     }
     return QString();
+}
+
+// Any PZS3US*.AFS left next to the extracted game data (their parent folder is
+// the deploy dir the runtime reads from).
+QStringList findAfsContainers(const QString &dataDir)
+{
+    QStringList out;
+    QDirIterator it(dataDir, QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        it.next();
+        const QString n = it.fileName().toUpper();
+        if (n.startsWith(QLatin1String("PZS3US")) && n.endsWith(QLatin1String(".AFS")))
+            out << it.filePath();
+    }
+    out.sort();
+    return out;
 }
 
 } // namespace
@@ -225,7 +243,13 @@ void InstallWizardDialog::buildUi()
             "QProgressBar { background:#1b222b; border:1px solid #2a3542; border-radius:4px; height:14px; }"
             "QProgressBar::chunk { background:#ff9e1a; border-radius:4px; }"));
         l->addWidget(m_bar);
-        l->addSpacing(12);
+        l->addSpacing(6);
+
+        m_activity = new QLabel(QString(), pageC);
+        m_activity->setWordWrap(true);
+        m_activity->setStyleSheet(QStringLiteral("font-size: 12px; color: #8b93a3;"));
+        l->addWidget(m_activity);
+        l->addSpacing(6);
 
         m_doneLabel = new QLabel(QString(), pageC);
         m_doneLabel->setWordWrap(true);
@@ -367,6 +391,11 @@ void InstallWizardDialog::onInstall()
 
 void InstallWizardDialog::onRetryInstall()
 {
+    if (m_inAfsPhase)
+    {
+        startAfsConversion();
+        return;
+    }
     if (m_isoPath.isEmpty())
     {
         setIndex(1);
@@ -380,6 +409,7 @@ void InstallWizardDialog::startExtraction()
     m_bar->setRange(0, 1);
     m_bar->setValue(0);
     m_progressText->setText(QStringLiteral("0 MB / 0 MB"));
+    m_activity->clear();
     m_doneLabel->setText(QStringLiteral("Installation in progress…"));
     m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
     m_retryInstall->setVisible(false);
@@ -415,8 +445,83 @@ void InstallWizardDialog::onExtractDone(bool ok, const QString &msg)
 {
     if (ok)
     {
+        const QString dataDir = QApplication::applicationDirPath() + QStringLiteral("/data");
+        if (!findAfsContainers(dataDir).isEmpty())
+        {
+            startAfsConversion();
+            return;
+        }
+        applyInstallResult(true, QStringLiteral("Installation complete. Game disc validated."));
+        return;
+    }
+    applyInstallResult(false, msg);
+}
+
+void InstallWizardDialog::startAfsConversion()
+{
+    const QString dataDir = QApplication::applicationDirPath() + QStringLiteral("/data");
+    const QStringList afs = findAfsContainers(dataDir);
+    if (afs.isEmpty())
+    {
+        applyInstallResult(true, QStringLiteral("Installation complete. Game disc validated."));
+        return;
+    }
+
+    m_inAfsPhase = true;
+    m_retryInstall->setVisible(false);
+    m_close->setEnabled(false);
+    m_bar->setRange(0, 1);
+    m_bar->setValue(0);
+    m_progressText->setText(QStringLiteral("0 MB / 0 MB"));
+    m_doneLabel->setText(QStringLiteral("Converting game data to folders…"));
+    m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #c9ccd4;"));
+    m_activity->setText(QStringLiteral("Preparing…"));
+    QCoreApplication::processEvents();
+
+    m_afsThread = new QThread;
+    m_afsWorker = new AfsExtractWorker;
+    m_afsWorker->moveToThread(m_afsThread);
+    connect(m_afsThread, &QThread::finished, m_afsWorker, &QObject::deleteLater);
+    connect(m_afsThread, &QThread::finished, m_afsThread, &QObject::deleteLater);
+    connect(m_afsWorker, &AfsExtractWorker::status, this, &InstallWizardDialog::onAfsStatus);
+    connect(m_afsWorker, &AfsExtractWorker::progress, this, &InstallWizardDialog::onAfsProgress);
+    connect(m_afsWorker, &AfsExtractWorker::done, this, &InstallWizardDialog::onAfsDone);
+    connect(m_afsWorker, &AfsExtractWorker::done, m_afsThread, &QThread::quit);
+    m_afsThread->start();
+
+    QMetaObject::invokeMethod(m_afsWorker, "doWork", Qt::QueuedConnection, Q_ARG(QStringList, afs));
+}
+
+void InstallWizardDialog::onAfsStatus(const QString &text)
+{
+    m_activity->setText(text);
+}
+
+void InstallWizardDialog::onAfsProgress(qint64 done, qint64 total)
+{
+    if (total > 0)
+        m_bar->setRange(0, static_cast<int>(total / (64 * 1024)));
+    m_bar->setValue(static_cast<int>(done / (64 * 1024)));
+    m_progressText->setText(
+        QStringLiteral("%1 MB / %2 MB").arg(fmtMb(done)).arg(fmtMb(total)));
+}
+
+void InstallWizardDialog::onAfsDone(bool ok, const QString &msg)
+{
+    m_inAfsPhase = false;
+    m_activity->clear();
+    if (ok)
+        applyInstallResult(true, QStringLiteral("Installation complete. Game data converted to folders."));
+    else
+        applyInstallResult(false, msg);
+}
+
+void InstallWizardDialog::applyInstallResult(bool ok, const QString &msg)
+{
+    if (ok)
+    {
         m_installed = true;
-        m_doneLabel->setText(QStringLiteral("Installation complete. Game disc validated."));
+        m_doneLabel->setText(msg);
         m_doneLabel->setStyleSheet(QStringLiteral("font-size: 13px; color: #22c55e;"));
         m_bar->setValue(m_bar->maximum());
     }

--- a/ps2xRuntime/src/launcher/install_wizard_dialog.h
+++ b/ps2xRuntime/src/launcher/install_wizard_dialog.h
@@ -9,6 +9,7 @@ class QStackedWidget;
 class QThread;
 class QTemporaryDir;
 class ExtractWorker;
+class AfsExtractWorker;
 
 // End-user install wizard: detects missing/corrupt game data, lets the user
 // point at their own disc dump (ISO or a container that wraps the ISO) and,
@@ -31,6 +32,9 @@ private slots:
     void onRetryInstall();
     void onExtractProgress(qint64 done, qint64 total);
     void onExtractDone(bool ok, const QString &msg);
+    void onAfsStatus(const QString &text);
+    void onAfsProgress(qint64 done, qint64 total);
+    void onAfsDone(bool ok, const QString &msg);
 
 private:
     void buildUi();
@@ -41,6 +45,10 @@ private:
     // image path, or an empty string. On failure err holds the user message.
     QString resolveInnerImage(const QString &dumpPath, QString *err);
     void startExtraction();
+    // Second install phase: turn every extracted PZS3US*.AFS into folder slots
+    // (+ .idx) and drop the container, leaving folders as the only data source.
+    void startAfsConversion();
+    void applyInstallResult(bool ok, const QString &msg);
 
     QStackedWidget *m_stack = nullptr;
 
@@ -52,8 +60,9 @@ private:
     QPushButton *m_nextDump = nullptr;
     QPushButton *m_retryDump = nullptr;
 
-    QLabel *m_progressText = nullptr; // page C
+    QLabel *m_progressText = nullptr;  // page C
     QProgressBar *m_bar = nullptr;
+    QLabel *m_activity = nullptr;      // live "what is happening now" line
     QLabel *m_doneLabel = nullptr;
     QPushButton *m_close = nullptr;
     QPushButton *m_retryInstall = nullptr;
@@ -63,7 +72,10 @@ private:
     QString m_isoPath; // verified image ready for extraction
     bool m_verified = false;
     bool m_installed = false;
+    bool m_inAfsPhase = false; // retry re-runs the AFS phase only
 
     QThread *m_thread = nullptr;
     ExtractWorker *m_worker = nullptr;
+    QThread *m_afsThread = nullptr;
+    AfsExtractWorker *m_afsWorker = nullptr;
 };

--- a/ps2xRuntime/src/launcher/install_wizard_dialog.h
+++ b/ps2xRuntime/src/launcher/install_wizard_dialog.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <QDialog>
+
+class QLabel;
+class QProgressBar;
+class QPushButton;
+class QStackedWidget;
+class QThread;
+class QTemporaryDir;
+class ExtractWorker;
+
+// End-user install wizard: detects missing/corrupt game data, lets the user
+// point at their own disc dump (ISO or a container that wraps the ISO) and,
+// after the embedded SHA-256 of SLUS_216.78 matches, extracts the game data
+// tree into the deployment folder so the runner can boot it.
+class InstallWizardDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit InstallWizardDialog(QWidget *parent = nullptr, bool reinstall = false);
+    ~InstallWizardDialog() override;
+
+    bool installed() const { return m_installed; }
+
+private slots:
+    void onNextMissing();
+    void onBrowse();
+    void onRetryDump();
+    void onInstall();
+    void onRetryInstall();
+    void onExtractProgress(qint64 done, qint64 total);
+    void onExtractDone(bool ok, const QString &msg);
+
+private:
+    void buildUi();
+    void setIndex(int index);
+    void setVerified(bool ok, const QString &text);
+    void attemptVerify(const QString &dumpPath);
+    // Unwraps a container (.rar/.7z/.zip/.tar...) and returns the inner disc
+    // image path, or an empty string. On failure err holds the user message.
+    QString resolveInnerImage(const QString &dumpPath, QString *err);
+    void startExtraction();
+
+    QStackedWidget *m_stack = nullptr;
+
+    QPushButton *m_nextMissing = nullptr; // page A
+    QLabel *m_selected = nullptr;         // page B
+    QPushButton *m_browse = nullptr;
+    QLabel *m_dot = nullptr;
+    QLabel *m_dotText = nullptr;
+    QPushButton *m_nextDump = nullptr;
+    QPushButton *m_retryDump = nullptr;
+
+    QLabel *m_progressText = nullptr; // page C
+    QProgressBar *m_bar = nullptr;
+    QLabel *m_doneLabel = nullptr;
+    QPushButton *m_close = nullptr;
+    QPushButton *m_retryInstall = nullptr;
+
+    QTemporaryDir *m_tmp = nullptr;
+    QString m_dumpPath;
+    QString m_isoPath; // verified image ready for extraction
+    bool m_verified = false;
+    bool m_installed = false;
+
+    QThread *m_thread = nullptr;
+    ExtractWorker *m_worker = nullptr;
+};

--- a/ps2xRuntime/src/launcher/iso9660.cpp
+++ b/ps2xRuntime/src/launcher/iso9660.cpp
@@ -1,0 +1,312 @@
+#include "iso9660.h"
+
+#include <QChar>
+#include <QDir>
+#include <QDirIterator>
+#include <QCryptographicHash>
+#include <QtEndian>
+
+#include <optional>
+
+namespace
+{
+constexpr quint32 kSectorSize = 2048;
+constexpr quint64 kPvdLba = 16;
+
+// ISO9660 directory record (34-byte base descriptor).
+struct DirRecord
+{
+    bool valid = false;
+    bool isDir = false;
+    bool multiExtent = false;
+    quint32 lba = 0;
+    quint64 size = 0;
+    QString name; // without ";N" version suffix, "." / ".." returned verbatim
+};
+
+quint32 le32(const QByteArray &b, int off)
+{
+    return static_cast<quint32>(static_cast<quint8>(b[off]))
+        | (static_cast<quint32>(static_cast<quint8>(b[off + 1])) << 8)
+        | (static_cast<quint32>(static_cast<quint8>(b[off + 2])) << 16)
+        | (static_cast<quint32>(static_cast<quint8>(b[off + 3])) << 24);
+}
+
+std::optional<DirRecord> parseRecord(const QByteArray &dirData, int *cursor)
+{
+    if (*cursor + 34 > dirData.size())
+        return std::nullopt;
+    const int len = static_cast<quint8>(dirData.at(*cursor));
+    if (len == 0)
+        return std::nullopt; // zero-length padding entries terminate the dir data
+    if (*cursor + len > dirData.size())
+        return std::nullopt;
+
+    DirRecord r;
+    r.lba = le32(dirData, *cursor + 2);
+    r.size = le32(dirData, *cursor + 10);
+    r.isDir = (static_cast<quint8>(dirData.at(*cursor + 25)) & 0x02) != 0;
+    r.multiExtent = (static_cast<quint8>(dirData.at(*cursor + 25)) & 0x80) != 0;
+    const int nameLen = static_cast<quint8>(dirData.at(*cursor + 32));
+    char ascii[256] = {};
+    for (int i = 0; i < nameLen && i < 255; ++i)
+        ascii[i] = static_cast<quint8>(dirData.at(*cursor + 33 + i));
+
+    // "." / ".." are stored as 0x00 / 0x01.
+    if (nameLen == 1 && (ascii[0] == '\0' || ascii[0] == '\x01'))
+    {
+        r.name = (ascii[0] == '\0') ? QStringLiteral(".") : QStringLiteral("..");
+    }
+    else
+    {
+        QString name = QString::fromLatin1(ascii, nameLen);
+        const int semi = name.indexOf(QLatin1Char(';'));
+        if (semi >= 0)
+            name.truncate(semi);
+        r.name = name;
+    }
+
+    *cursor += len;
+    return r;
+}
+} // namespace
+
+bool Iso9660::readBlocks(quint32 startLba, quint64 byteLen, const std::function<void(const QByteArray &)> &sink) const
+{
+    QFile f(m_path);
+    if (!f.open(QIODevice::ReadOnly))
+        return false;
+
+    const qint64 offset = static_cast<qint64>(startLba) * m_blockSize;
+    if (!f.seek(offset))
+        return false;
+
+    quint64 remaining = byteLen;
+    QByteArray buf;
+    buf.reserve(static_cast<int>(std::min<quint64>(256 * 1024, remaining ? remaining : 1)));
+    while (remaining > 0)
+    {
+        const qint64 want = static_cast<qint64>(std::min<quint64>(256 * 1024, remaining));
+        QByteArray chunk = f.read(want);
+        if (static_cast<quint64>(chunk.size()) != static_cast<quint64>(want))
+            return false; // short read: truncated file
+        remaining -= static_cast<quint64>(chunk.size());
+        sink(chunk);
+    }
+    return true;
+}
+
+bool Iso9660::open(const QString &isoPath)
+{
+    m_opened = false;
+    m_err.clear();
+    m_files.clear();
+    m_path = isoPath;
+
+    QFile f(isoPath);
+    if (!f.open(QIODevice::ReadOnly))
+    {
+        m_err = QStringLiteral("cannot open %1").arg(isoPath);
+        return false;
+    }
+
+    // Volume descriptors start at sector 16; a descriptor must fit in one sector.
+    QByteArray pvd;
+    {
+        pvd = f.read(static_cast<qint64>(16) * kSectorSize + kSectorSize);
+        if (pvd.size() < static_cast<int>(16) * kSectorSize + kSectorSize)
+        {
+            m_err = QStringLiteral("file too small to be an ISO image");
+            return false;
+        }
+    }
+    pvd = pvd.mid(static_cast<int>(16) * kSectorSize);
+
+    // Volume descriptor: [type(1)][standard-id "CD001"(5)][version(1)].
+    if (pvd.size() < 6 || pvd.mid(1, 5) != QByteArrayLiteral("CD001"))
+    {
+        m_err = QStringLiteral("not an ISO9660 image (missing CD001)");
+        return false;
+    }
+    if (static_cast<quint8>(pvd.at(0)) != 1)
+    {
+        m_err = QStringLiteral("primary volume descriptor not found");
+        return false;
+    }
+
+    const quint32 blockSize = static_cast<quint32>(static_cast<quint8>(pvd.at(128)))
+        | (static_cast<quint32>(static_cast<quint8>(pvd.at(129))) << 8);
+    if (blockSize != kSectorSize)
+    {
+        m_err = QStringLiteral("unsupported logical block size %1").arg(blockSize);
+        return false;
+    }
+
+    int cur = 156; // root directory record inside the PVD (both-endian 34-byte)
+    auto root = parseRecord(pvd, &cur);
+    if (!root || !root->isDir)
+    {
+        m_err = QStringLiteral("root directory record missing");
+        return false;
+    }
+
+    m_blockSize = blockSize;
+    m_opened = true;
+
+    if (!scanDirectory(root->lba, root->size, QString()))
+    {
+        m_opened = false;
+        m_err = QStringLiteral("failed to read directory tree: %1").arg(m_err);
+        return false;
+    }
+    return true;
+}
+
+bool Iso9660::scanDirectory(quint32 lba, quint64 byteLen, const QString &prefix)
+{
+    QByteArray dirData;
+    if (!readBlocks(lba, byteLen, [&](const QByteArray &chunk) { dirData.append(chunk); }))
+    {
+        m_err = QStringLiteral("short read on directory");
+        return false;
+    }
+
+    File *lastFile = nullptr;
+    int cursor = 0;
+    while (cursor < dirData.size())
+    {
+        const auto rec = parseRecord(dirData, &cursor);
+        if (!rec)
+            break; // padding terminates the directory listing
+
+        const QString path = prefix.isEmpty() ? rec->name : prefix + QLatin1Char('/') + rec->name;
+
+        if (rec->isDir)
+        {
+            if (rec->name != QStringLiteral(".") && rec->name != QStringLiteral(".."))
+            {
+                File d;
+                d.path = path;
+                d.dir = true;
+                m_files.append(d);
+                if (!scanDirectory(rec->lba, rec->size, path))
+                    return false;
+            }
+            lastFile = nullptr;
+            continue;
+        }
+
+        if (rec->multiExtent && lastFile && lastFile->path == path && lastFile->extents.size() >= 1)
+        {
+            lastFile->extents.append({rec->lba, rec->size});
+            continue;
+        }
+
+        File f;
+        f.path = path;
+        f.extents.append({rec->lba, rec->size});
+        m_files.append(f);
+        lastFile = &m_files.last();
+    }
+    return true;
+}
+
+const Iso9660::File *Iso9660::find(const QString &isoPath) const
+{
+    QString want = isoPath;
+    while (want.startsWith(QLatin1Char('/')))
+        want.remove(0, 1);
+    while (want.endsWith(QLatin1Char('/')))
+        want.chop(1);
+    const QString lowerWant = want.toLower();
+    for (const File &f : m_files)
+    {
+        if (!f.dir && f.path.toLower() == lowerWant)
+            return &f;
+    }
+    return nullptr;
+}
+
+qint64 Iso9660::readFile(const File &f, const std::function<void(const QByteArray &)> &sink) const
+{
+    QFile file(m_path);
+    if (!file.open(QIODevice::ReadOnly))
+        return -1;
+
+    qint64 total = 0;
+    for (const Extent &e : f.extents)
+    {
+        const qint64 offset = static_cast<qint64>(e.start) * m_blockSize;
+        if (!file.seek(offset))
+            return -1;
+        quint64 left = e.size;
+        while (left > 0)
+        {
+            const qint64 want = static_cast<qint64>(std::min<quint64>(256 * 1024, left));
+            QByteArray chunk = file.read(want);
+            if (static_cast<quint64>(chunk.size()) != static_cast<quint64>(want))
+                return -1;
+            left -= static_cast<quint64>(chunk.size());
+            total += chunk.size();
+            sink(chunk);
+        }
+    }
+    return total;
+}
+
+namespace DiscVerify
+{
+
+bool verifySlusFromIso(const QString &isoPath)
+{
+    Iso9660 iso;
+    if (!iso.open(isoPath))
+        return false;
+    const Iso9660::File *slus = iso.find(QStringLiteral("SLUS_216.78"));
+    if (!slus)
+        return false;
+
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    const qint64 got = iso.readFile(*slus, [&](const QByteArray &chunk) { hash.addData(chunk); });
+    if (got < 0)
+        return false;
+
+    return QString::fromLatin1(hash.result().toHex()) == QLatin1String(kExpectedDiscElfSha256);
+}
+
+State verifyInstalledData(const QString &dataDir)
+{
+    const QString boot = dataDir + QStringLiteral("/SLUS_216.78");
+    QFile f(boot);
+    if (!f.exists())
+        return State::Missing;
+
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    if (!f.open(QIODevice::ReadOnly))
+        return State::Corrupt;
+    QByteArray buf;
+    while (!f.atEnd())
+    {
+        buf = f.read(256 * 1024);
+        if (buf.isEmpty())
+            break;
+        hash.addData(buf);
+    }
+
+    const QString got = QString::fromLatin1(hash.result().toHex());
+    return (got == QLatin1String(kExpectedDiscElfSha256)) ? State::Valid : State::Corrupt;
+}
+
+quint64 dataSize(const QString &dataDir)
+{
+    quint64 total = 0;
+    QDirIterator it(dataDir, QDir::Files, QDirIterator::Subdirectories);
+    while (it.hasNext())
+    {
+        it.next();
+        total += static_cast<quint64>(it.fileInfo().size());
+    }
+    return total;
+}
+
+} // namespace DiscVerify

--- a/ps2xRuntime/src/launcher/iso9660.h
+++ b/ps2xRuntime/src/launcher/iso9660.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QByteArray>
+#include <QFile>
+#include <QList>
+#include <QPair>
+#include <QString>
+
+#include <functional>
+
+// Minimal ISO9660 reader (no external dependencies). Enough for PS2 game discs:
+// primary volume descriptor + directory records, both-endian fields, ";" version
+// suffix stripping and multi-extent files. Used by the Install Wizard to hash
+// the boot ELF inside the user's disc dump and to extract the game data tree.
+class Iso9660
+{
+public:
+    struct Extent
+    {
+        quint32 start = 0; // in logical blocks
+        quint64 size = 0;  // in bytes
+    };
+
+    struct File
+    {
+        QString path; // iso-style forward slashes, no leading '/', no ";1"
+        bool dir = false;
+        QList<Extent> extents;
+
+        quint64 size() const
+        {
+            quint64 total = 0;
+            for (const Extent &e : extents)
+                total += e.size;
+            return total;
+        }
+    };
+
+    bool open(const QString &isoPath);
+    bool isOpen() const { return m_opened; }
+    QString error() const { return m_err; }
+
+    const QList<File> &files() const { return m_files; }
+    // Case-insensitive lookup, e.g. "SLUS_216.78" or "BIN/DBZP.BIN".
+    const File *find(const QString &isoPath) const;
+
+    // Streams the whole file in 256 KiB chunks to sink(). Returns bytes read or -1.
+    qint64 readFile(const File &f, const std::function<void(const QByteArray &)> &sink) const;
+
+private:
+    bool readBlocks(quint32 startLba, quint64 byteLen, const std::function<void(const QByteArray &)> &sink) const;
+    bool scanDirectory(quint32 lba, quint64 byteLen, const QString &prefix);
+
+    QString m_path;
+    bool m_opened = false;
+    quint32 m_blockSize = 2048;
+    QString m_err;
+    QList<File> m_files;
+};
+
+// Disc-level verification for the launcher install wizard. The expected SHA-256
+// below is the hash of SLUS_216.78 (US release) and MUST stay in sync with the
+// ELF_SHA256 constant in games/bt3/setup.py.
+namespace DiscVerify
+{
+constexpr const char *kExpectedDiscElfSha256 = "811188ba9b416500d921cd4d9514df0cbf42f3a41a99cf5aac5a3da37171bf99";
+
+enum class State
+{
+    Missing, // data dir / boot ELF not present
+    Corrupt, // present but SHA-256 mismatch
+    Valid,   // SHA-256 matches
+};
+
+// Hash of the boot ELF embedded in an ISO image read with the local ISO9660 reader.
+bool verifySlusFromIso(const QString &isoPath);
+
+// Hash of the installed data/SLUS_216.78 next to the launcher.
+State verifyInstalledData(const QString &dataDir);
+
+// Total size in bytes of all files under dataDir.
+quint64 dataSize(const QString &dataDir);
+} // namespace DiscVerify

--- a/ps2xRuntime/src/launcher/launcher_window.cpp
+++ b/ps2xRuntime/src/launcher/launcher_window.cpp
@@ -1,6 +1,8 @@
 #include "launcher_window.h"
 
 #include "dbz_theme.h"
+#include "install_wizard_dialog.h"
+#include "iso9660.h"
 #include "settings_dialog.h"
 #include "settings_manager.h"
 
@@ -15,7 +17,9 @@
 #include <QProcess>
 #include <QPushButton>
 #include <QScreen>
+#include <QShowEvent>
 #include <QStandardPaths>
+#include <QTimer>
 #include <QVBoxLayout>
 
 #include <cstdio>
@@ -46,6 +50,7 @@ LauncherWindow::LauncherWindow(QWidget *parent)
 
     // The launcher lives in the deploy root; savedata/ is the shared settings dir.
     m_savedataDir = QDir(QApplication::applicationDirPath()).filePath(QStringLiteral("savedata"));
+    m_dataDir = QDir(QApplication::applicationDirPath()).filePath(QStringLiteral("data"));
 
     // Resolve the game ELF next to the launcher binary.
     const QDir appDir(QApplication::applicationDirPath());
@@ -122,6 +127,8 @@ LauncherWindow::LauncherWindow(QWidget *parent)
         m_hint->setText(QStringLiteral("  %1").arg(QFileInfo(m_gameElf).fileName()));
     barLayout->insertWidget(1, m_hint, 1, Qt::AlignVCenter | Qt::AlignLeft);
 
+    checkGameData();
+
     // Seed settings manager from the shared savedata dir.
     SettingsManager::instance().setConfigDir(m_savedataDir);
     SettingsManager::instance().load();
@@ -153,6 +160,14 @@ void LauncherWindow::onPlayClicked()
             return;
     }
 
+    // Game data must be present and validated before the runner can boot.
+    if (!m_gameDataValid)
+    {
+        // The install wizard restores data on success.
+        if (!openInstallWizard())
+            return;
+    }
+
     // Save any pending settings so the game boots with the launcher's config.
     SettingsManager::instance().save();
 
@@ -164,6 +179,43 @@ void LauncherWindow::onPlayClicked()
 
     // The launcher's job is done: close this window (the game runs on its own).
     close();
+}
+
+void LauncherWindow::checkGameData()
+{
+    m_gameDataValid = (DiscVerify::verifyInstalledData(m_dataDir) == DiscVerify::State::Valid);
+
+    if (m_play)
+        m_play->setEnabled(!m_gameElf.isEmpty() && m_gameDataValid);
+
+    if (!m_gameElf.isEmpty() && !m_gameDataValid)
+    {
+        m_hint->setText(QStringLiteral("  game data missing or corrupted - reinstall required"));
+    }
+}
+
+bool LauncherWindow::openInstallWizard()
+{
+    InstallWizardDialog dlg(this);
+    const bool installed = dlg.exec() == QDialog::Accepted;
+    checkGameData();
+    return installed && m_gameDataValid;
+}
+
+void LauncherWindow::showEvent(QShowEvent *e)
+{
+    QMainWindow::showEvent(e);
+
+    // Pop the install wizard automatically on first launch when the game data
+    // is missing/corrupt. The subsequent runs are user-initiated (PLAY button).
+    if (!m_gameDataValid && !m_wizardShown)
+    {
+        m_wizardShown = true;
+        QTimer::singleShot(0, this, [this] {
+            if (!m_gameDataValid)
+                openInstallWizard();
+        });
+    }
 }
 
 void LauncherWindow::onSettingsClicked()

--- a/ps2xRuntime/src/launcher/launcher_window.h
+++ b/ps2xRuntime/src/launcher/launcher_window.h
@@ -24,17 +24,23 @@ private slots:
 
 protected:
     void paintEvent(QPaintEvent *) override;
+    void showEvent(QShowEvent *) override;
 
 private:
     void loadBackground();
+    void checkGameData();
+    bool openInstallWizard();
 
     QLabel *m_hint = nullptr;
     QPushButton *m_play = nullptr;
     QPushButton *m_settings = nullptr;
     QWidget *m_bottomBar = nullptr;
-    QString m_gameElf;
-    QString m_bgPath;
     QProcess *m_gameProc = nullptr;
 
+    QString m_gameElf;
+    QString m_bgPath;
     QString m_savedataDir;
+    QString m_dataDir;
+    bool m_gameDataValid = false;
+    bool m_wizardShown = false;
 };

--- a/ps2xRuntime/src/launcher/settings_dialog.cpp
+++ b/ps2xRuntime/src/launcher/settings_dialog.cpp
@@ -6,6 +6,7 @@
 #include "tab_bindings.h"
 #include "tab_controllers.h"
 #include "tab_logging.h"
+#include "tab_misc.h"
 #include "tab_video.h"
 
 #include <QCloseEvent>
@@ -63,6 +64,7 @@ SettingsDialog::SettingsDialog(QWidget *parent)
     m_tabs->addTab(new ControllersTab(&m_bindings->players()), QStringLiteral("Controllers"));
     m_tabs->addTab(m_bindings, QStringLiteral("Bindings"));
     m_tabs->addTab(new LoggingTab, QStringLiteral("Logging"));
+    m_tabs->addTab(new MiscTab, QStringLiteral("Misc"));
     // Video/Controllers/Logging live-write into SettingsManager; load() the
     // INI once via the singleton constructor call pattern (see main.cpp).
     layout->addWidget(m_tabs, 1);

--- a/ps2xRuntime/src/launcher/settings_manager.cpp
+++ b/ps2xRuntime/src/launcher/settings_manager.cpp
@@ -220,24 +220,24 @@ bool SettingsManager::save()
     upsert("logging", "dump_runtime", m_dumpRuntime ? "1" : "0");
     upsert("logging", "dump_gamepad", m_dumpGamepad ? "1" : "0");
 
-    const QString tmp = path + ".tmp";
+    // Write the ini directly. A tmp+rename round-trip left a stale .tmp file
+    // behind and on some platforms failed to replace the existing ini, so the
+    // "Save" button appeared to do nothing.
+    QFile out(path);
+    if (!out.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
+        return false;
+    QTextStream ts(&out);
+    bool first = true;
+    for (auto it = sections.begin(); it != sections.end(); ++it)
     {
-        QFile out(tmp);
-        if (!out.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate))
-            return false;
-        QTextStream ts(&out);
-        bool first = true;
-        for (auto it = sections.begin(); it != sections.end(); ++it)
-        {
-            const Section &s = it.value();
-            if (!first)
-                ts << "\n";
-            first = false;
-            ts << "[" << it.key() << "]\n";
-            for (const QString &k : s.order)
-                ts << k << "=" << s.kv[k] << "\n";
-        }
-        ts.flush();
+        const Section &s = it.value();
+        if (!first)
+            ts << "\n";
+        first = false;
+        ts << "[" << it.key() << "]\n";
+        for (const QString &k : s.order)
+            ts << k << "=" << s.kv[k] << "\n";
     }
-    return QFile::rename(tmp, path);
+    ts.flush();
+    return true;
 }

--- a/ps2xRuntime/src/launcher/tab_misc.cpp
+++ b/ps2xRuntime/src/launcher/tab_misc.cpp
@@ -1,0 +1,185 @@
+#include "tab_misc.h"
+
+#include "install_wizard_dialog.h"
+#include "iso9660.h"
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QDesktopServices>
+#include <QDir>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QUrl>
+#include <QVBoxLayout>
+
+namespace
+{
+QString fmtSize(quint64 bytes)
+{
+    const QString gb = QString::number(bytes / (1024.0 * 1024.0 * 1024.0), 'f', 2);
+    return QStringLiteral("%1 GB").arg(gb);
+}
+} // namespace
+
+MiscTab::MiscTab(QWidget *parent)
+    : QWidget(parent)
+{
+    auto *scroll = new QScrollArea(this);
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+
+    auto *content = new QWidget;
+    auto *root = new QVBoxLayout(content);
+    root->setContentsMargins(14, 12, 14, 12);
+    root->setSpacing(6);
+
+    auto section = [](const QString &text) {
+        auto *l = new QLabel(text);
+        l->setObjectName(QStringLiteral("sectionLabel"));
+        return l;
+    };
+
+    root->addWidget(section(QStringLiteral("GAME DATA")));
+
+    // Size row.
+    {
+        auto *row = new QWidget;
+        auto *lay = new QHBoxLayout(row);
+        lay->setContentsMargins(8, 2, 8, 2);
+        auto *lbl = new QLabel(QStringLiteral("Size"));
+        lbl->setObjectName(QStringLiteral("valueLabel"));
+        lbl->setMinimumWidth(110);
+        m_size = new QLabel;
+        m_size->setObjectName(QStringLiteral("valueLabel"));
+        m_size->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        lay->addWidget(lbl);
+        lay->addStretch(1);
+        lay->addWidget(m_size);
+        root->addWidget(row);
+    }
+
+    // Validity row (colored dot + label).
+    {
+        auto *row = new QWidget;
+        auto *lay = new QHBoxLayout(row);
+        lay->setContentsMargins(8, 2, 8, 2);
+        auto *lbl = new QLabel(QStringLiteral("Status"));
+        lbl->setObjectName(QStringLiteral("valueLabel"));
+        lbl->setMinimumWidth(110);
+        m_dot = new QLabel(QStringLiteral("●"));
+        m_dot->setStyleSheet(QStringLiteral("font-size: 15px; color: #8b93a3;"));
+        m_dotText = new QLabel;
+        m_dotText->setObjectName(QStringLiteral("hintLabel"));
+        m_dotText->setWordWrap(true);
+        lay->addWidget(lbl);
+        lay->addWidget(m_dot);
+        lay->addWidget(m_dotText, 1);
+        root->addWidget(row);
+    }
+
+    // Folder row: opens the installed game-data folder.
+    {
+        auto *row = new QWidget;
+        auto *lay = new QHBoxLayout(row);
+        lay->setContentsMargins(8, 2, 8, 2);
+        auto *lbl = new QLabel(QStringLiteral("Folder"));
+        lbl->setObjectName(QStringLiteral("valueLabel"));
+        lbl->setMinimumWidth(110);
+        m_browse = new QPushButton(QStringLiteral("Browse…"), row);
+        m_browse->setObjectName(QStringLiteral("wizardButton"));
+        m_browse->setCursor(Qt::PointingHandCursor);
+        lay->addWidget(lbl);
+        lay->addStretch(1);
+        lay->addWidget(m_browse);
+        root->addWidget(row);
+    }
+
+    root->addSpacing(8);
+
+    // Reinstall mode toggle -> reveals the Install Wizard button.
+    {
+        auto *row = new QWidget;
+        auto *lay = new QHBoxLayout(row);
+        lay->setContentsMargins(8, 2, 8, 2);
+        auto *lbl = new QLabel(QStringLiteral("Reinstall Mode"));
+        lbl->setObjectName(QStringLiteral("valueLabel"));
+        m_reinstall = new QCheckBox;
+        m_reinstall->setObjectName(QStringLiteral("reinstallModeCheck"));
+        lay->addWidget(lbl, 1);
+        lay->addWidget(m_reinstall);
+        root->addWidget(row);
+    }
+
+    m_wizardBtn = new QPushButton(QStringLiteral("Installation wizard…"), content);
+    m_wizardBtn->setObjectName(QStringLiteral("wizardButton"));
+    m_wizardBtn->setCursor(Qt::PointingHandCursor);
+    m_wizardBtn->setVisible(false);
+    root->addWidget(m_wizardBtn);
+
+    root->addStretch(1);
+    scroll->setWidget(content);
+
+    auto *outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->addWidget(scroll);
+
+    connect(m_reinstall, &QCheckBox::toggled, this, &MiscTab::onReinstallMode);
+    connect(m_wizardBtn, &QPushButton::clicked, this, &MiscTab::onInstallWizard);
+    connect(m_browse, &QPushButton::clicked, this, &MiscTab::onOpenFolder);
+
+    refresh();
+}
+
+void MiscTab::refresh()
+{
+    const QString dataDir = QApplication::applicationDirPath() + QStringLiteral("/data");
+    const DiscVerify::State st = DiscVerify::verifyInstalledData(dataDir);
+
+    m_size->setText(fmtSize(DiscVerify::dataSize(dataDir)));
+
+    QString color;
+    QString text;
+    switch (st)
+    {
+    case DiscVerify::State::Valid:
+        color = QStringLiteral("#22c55e");
+        text = QStringLiteral("Installed and validated");
+        break;
+    case DiscVerify::State::Missing:
+        color = QStringLiteral("#ef4444");
+        text = QStringLiteral("Missing");
+        break;
+    case DiscVerify::State::Corrupt:
+        color = QStringLiteral("#ef4444");
+        text = QStringLiteral("Corrupted - reinstall required");
+        break;
+    }
+    m_dot->setStyleSheet(QStringLiteral("font-size: 15px; color: %1;").arg(color));
+    m_dotText->setText(text);
+
+    m_reinstall->setChecked(m_reinstall->isChecked());
+    m_wizardBtn->setVisible(m_reinstall->isChecked());
+}
+
+void MiscTab::onReinstallMode(bool on)
+{
+    m_wizardBtn->setVisible(on);
+}
+
+void MiscTab::onInstallWizard()
+{
+    InstallWizardDialog dlg(this, /*reinstall=*/true);
+    if (dlg.exec() == QDialog::Accepted)
+        refresh();
+}
+
+void MiscTab::onOpenFolder()
+{
+    const QString dataDir = QApplication::applicationDirPath() + QStringLiteral("/data");
+    const QString target = QDir(dataDir).exists() ? dataDir : QApplication::applicationDirPath();
+    if (!QDir().mkpath(target))
+        return;
+    QDesktopServices::openUrl(QUrl::fromLocalFile(target));
+}

--- a/ps2xRuntime/src/launcher/tab_misc.h
+++ b/ps2xRuntime/src/launcher/tab_misc.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QWidget>
+
+class QCheckBox;
+class QLabel;
+class QPushButton;
+
+// "Misc" settings tab: shows the installed game data status (size + validity
+// dot) and a Reinstall Mode toggle that exposes the Install Wizard.
+class MiscTab : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit MiscTab(QWidget *parent = nullptr);
+    void refresh();
+
+private slots:
+    void onReinstallMode(bool on);
+    void onInstallWizard();
+    void onOpenFolder();
+
+private:
+    QLabel *m_size = nullptr;
+    QLabel *m_dot = nullptr;
+    QLabel *m_dotText = nullptr;
+    QCheckBox *m_reinstall = nullptr;
+    QPushButton *m_wizardBtn = nullptr;
+    QPushButton *m_browse = nullptr;
+};

--- a/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
+++ b/ps2xRuntime/src/lib/Kernel/Stubs/Helpers/Support.h
@@ -4,11 +4,17 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cctype>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <vector>
 
 namespace
 {
     constexpr uint32_t kCdSectorSize = 2048;
     constexpr uint32_t kCdPseudoLbnStart = 0x00100000;
+
+    struct CdAfTable;
 
     struct CdFileEntry
     {
@@ -16,7 +22,33 @@ namespace
         uint32_t sizeBytes = 0;
         uint32_t baseLbn = 0;
         uint32_t sectors = 0;
+        std::shared_ptr<CdAfTable> afsFolder;   // non-null when served from extracted folders
     };
+
+    // One AFS slot (entry id == index into .slots). slotBytes is the physical disk
+    // slice [offset, offset+slotBytes): the raw entry bytes plus any padding that was
+    // on the disc, preserved verbatim (idx v2).
+    struct CdAfSlot
+    {
+        uint32_t offset = 0;
+        uint32_t size = 0;        // logical (declared) entry size
+        uint32_t slotBytes = 0;   // physical slice size
+    };
+
+    // Folder-backed AFS: the original single .AFS blob is presented as a virtual
+    // file assembled from an extracted folder (PZS3US<N>/%06zu) plus the verbatim
+    // index blob [0, indexBytes). Loaded from the <base>.idx sidecar written by
+    // tools/afs_extract.
+    struct CdAfTable
+    {
+        std::filesystem::path folder;
+        std::vector<CdAfSlot> slots;
+        uint32_t afsBytes = 0;
+        uint32_t indexBytes = 0;
+        std::vector<uint8_t> indexBlob;
+        bool valid = false;
+    };
+
 
     std::unordered_map<std::string, CdFileEntry> g_cdFilesByKey;
     std::unordered_map<std::string, std::filesystem::path> g_cdLeafIndex;
@@ -342,6 +374,199 @@ namespace
         }
     }
 
+    std::shared_ptr<CdAfTable> loadFolderTable(const std::filesystem::path &idxPath,
+                                               const std::filesystem::path &folderPath)
+    {
+        auto table = std::make_shared<CdAfTable>();
+        std::ifstream idx(idxPath, std::ios::binary);
+        if (!idx.is_open())
+        {
+            return nullptr;
+        }
+
+        char magic[8] = {};
+        idx.read(magic, 8);
+        if (std::memcmp(magic, "DBZAFS01", 8) != 0)
+        {
+            return nullptr;
+        }
+
+        uint32_t version = 0, count = 0, afsBytes = 0, indexBytes = 0;
+        auto readU32 = [&idx](uint32_t &v) { idx.read(reinterpret_cast<char *>(&v), 4); return !idx.fail(); };
+        if (!readU32(version) || !readU32(count) || !readU32(afsBytes) || !readU32(indexBytes))
+        {
+            return nullptr;
+        }
+        if (version != 2u || indexBytes > afsBytes)
+        {
+            return nullptr;
+        }
+
+        table->slots.reserve(count);
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            uint32_t off = 0, sz = 0, slotBytes = 0, type = 0;
+            if (!readU32(off) || !readU32(sz) || !readU32(slotBytes) || !readU32(type))
+            {
+                return nullptr;
+            }
+            if (off < indexBytes || sz == 0u || slotBytes < sz || off + slotBytes > afsBytes ||
+                off % kCdSectorSize != 0)
+            {
+                return nullptr;
+            }
+            if (!table->slots.empty())
+            {
+                const CdAfSlot &prev = table->slots.back();
+                if (off < prev.offset + prev.slotBytes)   // slots must be strictly contiguous
+                {
+                    return nullptr;
+                }
+            }
+            table->slots.push_back({off, sz, slotBytes});
+        }
+
+        table->indexBlob.resize(indexBytes);
+        if (indexBytes > 0)
+        {
+            idx.read(reinterpret_cast<char *>(table->indexBlob.data()), indexBytes);
+            if (idx.gcount() != static_cast<std::streamsize>(indexBytes))
+            {
+                return nullptr;
+            }
+            if (std::memcmp(table->indexBlob.data(), "AFS\0", 4) != 0)
+            {
+                return nullptr;
+            }
+        }
+
+        table->folder = folderPath;
+        table->afsBytes = afsBytes;
+        table->indexBytes = indexBytes;
+        table->valid = true;
+        return table;
+    }
+
+    bool readFolderRange(const CdFileEntry &entry, uint64_t relOffset, uint8_t *dst, size_t byteCount)
+    {
+        const CdAfTable &table = *entry.afsFolder;
+        if (!dst)
+        {
+            g_lastCdError = -1;
+            return false;
+        }
+        if (byteCount == 0)
+        {
+            g_lastCdError = 0;
+            return true;
+        }
+
+        {
+            const std::vector<CdAfSlot> &slots = table.slots;
+            auto it = std::upper_bound(slots.begin(), slots.end(), relOffset,
+                                       [](uint64_t p, const CdAfSlot &s) { return p < s.offset; });
+            if (it != slots.begin())
+            {
+                const uint64_t id = static_cast<uint64_t>((it - 1) - slots.begin());
+                char nm[32];
+                std::snprintf(nm, sizeof(nm), "%06llu", static_cast<unsigned long long>(id));
+                const CdAfSlot &slot = *(it - 1);
+                std::printf("[slot-read] \"%s\" off=%llu n=%zu\n",
+                            (table.folder / nm).string().c_str(),
+                            static_cast<unsigned long long>(relOffset - slot.offset), byteCount);
+            }
+        }
+
+        std::memset(dst, 0, byteCount);
+        const std::vector<CdAfSlot> &slots = table.slots;
+        size_t done = 0;
+        while (done < byteCount)
+        {
+            const uint64_t pos = relOffset + done;
+            if (pos < table.indexBytes)
+            {
+                const size_t n = static_cast<size_t>(std::min<uint64_t>(table.indexBytes - pos, byteCount - done));
+                std::memcpy(dst + done, table.indexBlob.data() + static_cast<size_t>(pos), n);
+                done += n;
+                continue;
+            }
+            if (pos >= table.afsBytes)
+            {
+                std::memset(dst + done, 0, byteCount - done);   // read past EOF -> zeros
+                done = byteCount;
+                break;
+            }
+
+            auto it = std::upper_bound(slots.begin(), slots.end(), pos,
+                                       [](uint64_t p, const CdAfSlot &s) { return p < s.offset; });
+            if (it == slots.begin())
+            {
+                // Before the first data offset: virtual padding, keep zeros.
+                std::memset(dst + done, 0, byteCount - done);
+                done = byteCount;
+                break;
+            }
+
+            const CdAfSlot &slot = *(it - 1);
+            const uint64_t slotEnd = slot.offset + static_cast<uint64_t>(slot.slotBytes);
+            if (pos >= slotEnd)
+            {
+                // Between physical slots (should not occur for contiguous archives),
+                // zero-fill until the next slot or EOF.
+                uint64_t zeroTo = table.afsBytes;
+                if (it != slots.end())
+                {
+                    zeroTo = slots[static_cast<size_t>(it - slots.begin())].offset;
+                }
+                const size_t n = static_cast<size_t>(std::min<uint64_t>(zeroTo - pos, byteCount - done));
+                std::memset(dst + done, 0, n);
+                done += n;
+                continue;
+            }
+
+            // slot files carry the full physical slice [offset, offset+slotBytes)
+            // verbatim, padding included, so every byte is read straight from disk.
+            const uint64_t inFile = pos - slot.offset;
+            const size_t room = static_cast<size_t>(std::min<uint64_t>(slotEnd - pos, byteCount - done));
+            const size_t fromFile = room;
+
+            bool ok = true;
+            if (fromFile > 0)
+            {
+                char name[32];
+                const uint64_t id = static_cast<uint64_t>(it - 1 - slots.begin());
+                std::snprintf(name, sizeof(name), "%06llu", static_cast<unsigned long long>(id));
+                const std::string filePath = (table.folder / name).string();
+                std::cerr << "\"" << filePath << "\"" << std::endl;
+                std::ifstream file(table.folder / name, std::ios::binary);
+                if (file.is_open())
+                {
+                    file.seekg(static_cast<std::streamoff>(inFile), std::ios::beg);
+                    file.read(reinterpret_cast<char *>(dst + done), static_cast<std::streamsize>(fromFile));
+                    const std::streamsize got = file.gcount();
+                    if (got < static_cast<std::streamsize>(fromFile))
+                    {
+                        std::memset(dst + done + static_cast<size_t>(got), 0,
+                                    fromFile - static_cast<size_t>(got));
+                    }
+                    file.close();
+                }
+                else
+                {
+                    ok = false;
+                }
+            }
+            done += room;   // 'room' covers the copied physical slice bytes
+            if (!ok)
+            {
+                g_lastCdError = -1;
+                return false;
+            }
+        }
+
+        g_lastCdError = 0;
+        return true;
+    }
     bool registerCdFile(const std::string &ps2Path, CdFileEntry &entryOut)
     {
         const std::string key = cdPathKey(ps2Path);
@@ -361,8 +586,31 @@ namespace
 
         const std::filesystem::path root = getCdRootPath();
         std::filesystem::path path = cdHostPath(ps2Path);
+
+        // Serve PZS3US*.AFS as a virtual byte-identical blob assembled from the
+        // extracted folder (PZS3US1/ + PZS3US1.idx sidecar). Detected next to the
+        // host path: <stem>.idx + directory <stem>/. Runs BEFORE the host-file
+        // existence gate so it also keeps working when the .AFS itself has been
+        // deleted (the whole point of folder-backing).
+        std::shared_ptr<CdAfTable> afTable;
+        if (key.size() > 4 && key.compare(key.size() - 4, 4, ".afs") == 0)
+        {
+            const std::filesystem::path stem = path.stem();
+            const std::filesystem::path idxCandidate = path.parent_path() / (stem.string() + ".idx");
+            const std::filesystem::path folderCandidate = path.parent_path() / stem;
+            std::error_code e1, e2;
+            if (std::filesystem::exists(idxCandidate, e1) &&
+                std::filesystem::is_directory(folderCandidate, e2))
+            {
+                afTable = loadFolderTable(idxCandidate, folderCandidate);
+            }
+        }
+
         std::error_code ec;
-        if (!std::filesystem::exists(path, ec) || ec || !std::filesystem::is_regular_file(path, ec))
+        uint64_t sizeBytes = 0;
+        if (!afTable)
+        {
+            if (!std::filesystem::exists(path, ec) || ec || !std::filesystem::is_regular_file(path, ec))
         {
             const std::filesystem::path relative(normalizeCdPathNoPrefix(ps2Path));
             std::filesystem::path resolvedCasePath;
@@ -399,18 +647,24 @@ namespace
             }
         }
 
-        const uint64_t sizeBytes = std::filesystem::file_size(path, ec);
-        if (ec)
-        {
-            g_lastCdError = -1;
-            return false;
+        sizeBytes = std::filesystem::file_size(path, ec);
+            if (ec)
+            {
+                g_lastCdError = -1;
+                return false;
+            }
         }
+
+        const uint32_t effectiveSize = afTable
+            ? std::min<uint64_t>(afTable->afsBytes, 0xFFFFFFFFu)
+            : static_cast<uint32_t>(std::min<uint64_t>(sizeBytes, 0xFFFFFFFFu));
 
         CdFileEntry entry;
         entry.hostPath = path;
-        entry.sizeBytes = static_cast<uint32_t>(std::min<uint64_t>(sizeBytes, 0xFFFFFFFFu));
+        entry.sizeBytes = effectiveSize;
         entry.baseLbn = g_nextPseudoLbn;
-        entry.sectors = sectorsForBytes(sizeBytes);
+        entry.sectors = sectorsForBytes(effectiveSize);
+        entry.afsFolder = afTable;
 
         g_nextPseudoLbn += entry.sectors + 1;
         g_cdFilesByKey.emplace(key, entry);
@@ -513,6 +767,10 @@ namespace
 
             const uint64_t relativeLbn = static_cast<uint64_t>(lbn - entry.baseLbn);
             const uint64_t offset = relativeLbn * kCdSectorSize;
+            if (entry.afsFolder)
+            {
+                return readFolderRange(entry, offset, dst, byteCount);
+            }
             return readHostRange(entry.hostPath, offset, dst, byteCount);
         }
 

--- a/ps2xRuntime/src/lib/pad_config.cpp
+++ b/ps2xRuntime/src/lib/pad_config.cpp
@@ -1295,6 +1295,73 @@ namespace ps2_stubs
             slotValue(cfg.binds[static_cast<size_t>(PadAction::RStickYNeg)]) +
                 slotValue(cfg.binds[static_cast<size_t>(PadAction::RStickYPos)]),
             -1.0f, 1.0f);
+#if defined(__linux__)
+        // Native evdev sticks: the singleton is one physical device = the launcher's
+        // "Gamepad 0". When raylib has a GLFW mapping for it the digital side works
+        // but a half-mapped SDL entry can zero the analogue axes (buttons/bumpers and
+        // even triggers still arrive via their own paths), leaving the sticks dead:
+        // slotValue() only reads raylib slots and the old fallback required pads to
+        // be EMPTY. Blend the native deflection into each stick when it is stronger,
+        // but only for the native owner (per-player leak guard, same rule as buttons).
+        if (nativeOwner)
+        {
+            auto mergeStick = [&](float &dst, int axis, const PadBind &neg, const PadBind &pos)
+            {
+                const float nv = native.getAxis(axis);
+                float v = 0.0f;
+                if (neg.kind == PadBindKind::Axis && neg.sign < 0.0f && nv < 0.0f)
+                    v = nv;
+                else if (pos.kind == PadBindKind::Axis && pos.sign > 0.0f && nv > 0.0f)
+                    v = nv;
+                if (std::fabs(v) > std::fabs(dst))
+                {
+                    dst = v;
+                }
+            };
+            mergeStick(lx, GAMEPAD_AXIS_LEFT_X,
+                       cfg.binds[static_cast<size_t>(PadAction::LStickXNeg)],
+                       cfg.binds[static_cast<size_t>(PadAction::LStickXPos)]);
+            mergeStick(ly, GAMEPAD_AXIS_LEFT_Y,
+                       cfg.binds[static_cast<size_t>(PadAction::LStickYNeg)],
+                       cfg.binds[static_cast<size_t>(PadAction::LStickYPos)]);
+            mergeStick(rx, GAMEPAD_AXIS_RIGHT_X,
+                       cfg.binds[static_cast<size_t>(PadAction::RStickXNeg)],
+                       cfg.binds[static_cast<size_t>(PadAction::RStickXPos)]);
+            mergeStick(ry, GAMEPAD_AXIS_RIGHT_Y,
+                       cfg.binds[static_cast<size_t>(PadAction::RStickYNeg)],
+                       cfg.binds[static_cast<size_t>(PadAction::RStickYPos)]);
+        }
+        // [padprobe] PS2X_PADPROBE=1: once (60th frame) dump what each input world
+        // sees for the pad, so a dead path is distinguishable from hardware state.
+        static const bool s_probe = [](){ const char *v = std::getenv("PS2X_PADPROBE"); return v && v[0] == '1'; }();
+        if (s_probe)
+        {
+            static int s_probeFrame = 0;
+            if (++s_probeFrame == 60)
+            {
+                for (int pad : pads)
+                {
+                    std::fprintf(stdout, "[padprobe] slot=%d nativeAvail=%d nativeMatch=%d\n",
+                                 pad, native.isAvailable() ? 1 : 0, nativeOk ? 1 : 0);
+                    std::fprintf(stdout, "[padprobe] raylib axes 0..5: %.3f %.3f %.3f %.3f %.3f %.3f\n",
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_LEFT_X),
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_LEFT_Y),
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_RIGHT_X),
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_RIGHT_Y),
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_LEFT_TRIGGER),
+                                 GetGamepadAxisMovement(pad, GAMEPAD_AXIS_RIGHT_TRIGGER));
+                    std::fprintf(stdout, "[padprobe] native  axes 0..5: %.3f %.3f %.3f %.3f %.3f %.3f\n",
+                                 native.getAxis(GAMEPAD_AXIS_LEFT_X), native.getAxis(GAMEPAD_AXIS_LEFT_Y),
+                                 native.getAxis(GAMEPAD_AXIS_RIGHT_X), native.getAxis(GAMEPAD_AXIS_RIGHT_Y),
+                                 native.getAxis(GAMEPAD_AXIS_LEFT_TRIGGER), native.getAxis(GAMEPAD_AXIS_RIGHT_TRIGGER));
+                    std::fprintf(stdout, "[padprobe] buttons raylib(9,10,16,17)=%d%d%d%d native(16,17)=%d%d\n",
+                                 IsGamepadButtonDown(pad, 9), IsGamepadButtonDown(pad, 10),
+                                 IsGamepadButtonDown(pad, 16), IsGamepadButtonDown(pad, 17),
+                                 native.isButtonDown(16), native.isButtonDown(17));
+                }
+            }
+        }
+#endif
 
         // Fallback: if GLFW has no mapping for the controller (pads empty)
         // but the native evdev reader is available, read axes directly. Only

--- a/ps2xRuntime/src/lib/ps2_gs_gpu_renderer.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu_renderer.cpp
@@ -1436,7 +1436,7 @@ namespace
 
 bool GsGpuRenderer::enabled()
 {
-    return uiFlag(g_uiGpu, "PS2X_GPU", false);
+    return uiFlag(g_uiGpu, "PS2X_GPU", true);
 }
 
 GsGpuRenderer &ps2GpuRenderer()

--- a/ps2xRuntime/src/lib/ps2_settings_overlay.cpp
+++ b/ps2xRuntime/src/lib/ps2_settings_overlay.cpp
@@ -340,15 +340,58 @@ void PS2SettingsOverlay::initialize()
     buildDeviceList();
     // Apply all loaded settings (glow, postfx, volume, etc.) at startup.
     applySettings();
+    // Snapshot the persisted settings so shutdown() only rewrites the ini when the
+    // session actually changed something (keeps launcher-authored values intact).
+    m_settingsAtBoot = m_settings;
 }
 
 void PS2SettingsOverlay::shutdown()
 {
     if (!m_initialized)
         return;
-    saveSettings();
+    // Persist only when something changed this session OR no ini exists yet
+    // (first boot seeds the default file). Otherwise leave the existing
+    // ini untouched so launcher-authored settings survive a play session.
+    if (!(m_settings == m_settingsAtBoot) || !std::filesystem::exists(m_configPath))
+        saveSettings();
     rlImGuiShutdown();
     m_initialized = false;
+}
+
+bool PS2SettingsOverlay::Settings::operator==(const Settings &o) const
+{
+    return masterVolume == o.masterVolume &&
+           musicVolume == o.musicVolume &&
+           sfxVolume == o.sfxVolume &&
+           gpuRenderer == o.gpuRenderer &&
+           glow == o.glow &&
+           postfx == o.postfx &&
+           glowFix == o.glowFix &&
+           bilinear == o.bilinear &&
+           halfTexel == o.halfTexel &&
+           skipPost == o.skipPost &&
+           skipStaleVram == o.skipStaleVram &&
+           renderScale == o.renderScale &&
+           deadzone == o.deadzone &&
+           fullscreen == o.fullscreen &&
+           widescreen == o.widescreen &&
+           outline == o.outline &&
+           texPack == o.texPack &&
+           inkStrength == o.inkStrength &&
+           shadows == o.shadows &&
+           dofBlur == o.dofBlur &&
+           dofZFar == o.dofZFar &&
+           windowW == o.windowW &&
+           windowH == o.windowH &&
+           forceBilinear == o.forceBilinear &&
+           overlayEnabled == o.overlayEnabled &&
+           hudLayout == o.hudLayout &&
+           hudOffL == o.hudOffL &&
+           hudOffC == o.hudOffC &&
+           hudOffR == o.hudOffR &&
+           overlayPadBtns == o.overlayPadBtns &&
+           overlayKeys == o.overlayKeys &&
+           logLevel == o.logLevel;
 }
 
 void PS2SettingsOverlay::resetCaptureState()

--- a/tools/afs_extract/.gitignore
+++ b/tools/afs_extract/.gitignore
@@ -1,0 +1,1 @@
+/afs_extract

--- a/tools/afs_extract/afs_extract.cpp
+++ b/tools/afs_extract/afs_extract.cpp
@@ -1,0 +1,334 @@
+// AFS container extractor + roster classifier for Dragon Ball: Budokai Tenkaichi 3
+// (PZS3US*.AFS). Native C++17, cross-platform, no external deps.
+//
+// Build:  g++ -O2 -std=c++17 afs_extract.cpp -o afs_extract
+//
+// Usage:
+//   afs_extract info  <PZS3US*.AFS>...            // dump entry table / roster summary
+//   afs_extract dump  <outDir> <PZS3US*.AFS>...   // extract each into <outDir>/<base>/ + <base>.idx
+//   afs_extract verify <outDir> <PZS3US*.AFS>...  // byte-compare extracted vs source
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <algorithm>
+
+namespace fs = std::filesystem;
+
+struct Entry {
+    uint32_t off = 0;
+    uint32_t size = 0;
+    uint32_t type = 0;
+};
+
+static const char kAfsMagic[4] = {'A', 'F', 'S', 0};                // "AFS\0"
+static const char kIdxMagic[8] = {'D', 'B', 'Z', 'A', 'F', 'S', '0', '1'};
+
+enum Type : uint32_t {
+    T_OTHER = 0,
+    T_MODEL = 1,    // word0=0xFC word1=0x400  -> *_{1..4}p.pak costumes
+    T_ANIM  = 2,    // word0=0x1B8 word1=0x700 -> *_anm.pak
+    T_EFF   = 3,    // word0=0x6   word1=0x40  -> *_eff.pak
+    T_PAK1  = 4,    // word0=0x1   word1=0x40
+    T_PAK3  = 5,    // word0=0x3   word1=0x40
+    T_Q1    = 6,    // word0=0x1   word1=0x8
+    T_S12C  = 7,    // word0=0x12C word1=0x4C0
+    T_R19   = 8,    // word0=0x19  word1=0x80
+    T_GS    = 9,    // word0=0x435347 ("GS\x43...")
+    T_PAK2  = 10,   // word0=0x2   word1=0x40
+};
+
+static uint32_t classify(const uint8_t *head, uint32_t avail)
+{
+    if (avail < 8) return T_OTHER;
+    uint32_t w0, w1;
+    std::memcpy(&w0, head, 4);
+    std::memcpy(&w1, head + 4, 4);
+    if (w0 == 0xFC && w1 == 0x400) return T_MODEL;
+    if (w0 == 0x1B8 && w1 == 0x700) return T_ANIM;
+    if (w0 == 0x6 && w1 == 0x40) return T_EFF;
+    if (w0 == 0x1 && w1 == 0x40) return T_PAK1;
+    if (w0 == 0x3 && w1 == 0x40) return T_PAK3;
+    if (w0 == 0x1 && w1 == 0x8) return T_Q1;
+    if (w0 == 0x12C && w1 == 0x4C0) return T_S12C;
+    if (w0 == 0x19 && w1 == 0x80) return T_R19;
+    if (w0 == 0x435347) return T_GS;
+    if (w0 == 0x2 && w1 == 0x40) return T_PAK2;
+    return T_OTHER;
+}
+
+static const char *typeName(uint32_t t)
+{
+    switch (t) {
+        case T_MODEL: return "MODEL";
+        case T_ANIM:  return "ANIM";
+        case T_EFF:   return "EFF";
+        case T_PAK1:  return "PAK1";
+        case T_PAK3:  return "PAK3";
+        case T_Q1:    return "Q1";
+        case T_S12C:  return "S12C";
+        case T_R19:   return "R19";
+        case T_GS:    return "GS";
+        case T_PAK2:  return "PAK2";
+        default:      return "OTHER";
+    }
+}
+
+static bool readFile(const fs::path &p, std::vector<uint8_t> &out)
+{
+    std::FILE *f = std::fopen(p.string().c_str(), "rb");
+    if (!f) return false;
+    std::fseek(f, 0, SEEK_END);
+    long sz = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    if (sz < 0) { std::fclose(f); return false; }
+    out.resize(static_cast<size_t>(sz));
+    if (sz > 0 && std::fread(out.data(), 1, out.size(), f) != out.size()) {
+        std::fclose(f);
+        return false;
+    }
+    std::fclose(f);
+    return true;
+}
+
+static bool parseAfs(const fs::path &p, std::vector<Entry> &entries)
+{
+    std::vector<uint8_t> data;
+    if (!readFile(p, data)) {
+        std::fprintf(stderr, "error: cannot read %s\n", p.string().c_str());
+        return false;
+    }
+    if (data.size() < 8) {
+        std::fprintf(stderr, "error: %s too small\n", p.string().c_str());
+        return false;
+    }
+    uint32_t magic;
+    std::memcpy(&magic, data.data(), 4);
+    if (std::memcmp(&magic, kAfsMagic, 4) != 0) {
+        std::fprintf(stderr, "error: %s is not an AFS container\n", p.string().c_str());
+        return false;
+    }
+    uint32_t count;
+    std::memcpy(&count, data.data() + 4, 4);
+    if (data.size() < 8ull + count * 8ull) {
+        std::fprintf(stderr, "error: %s truncated table\n", p.string().c_str());
+        return false;
+    }
+    entries.clear();
+    entries.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        uint32_t off, sz;
+        std::memcpy(&off, data.data() + 8 + i * 8, 4);
+        std::memcpy(&sz, data.data() + 8 + i * 8 + 4, 4);
+        uint32_t type = T_OTHER;
+        if (off + 8 <= data.size()) {
+            type = classify(data.data() + off, std::min<uint32_t>(sz, 8));
+        }
+        entries.push_back({off, sz, type});
+    }
+    return true;
+}
+
+static void printRoster(const std::vector<Entry> &e)
+{
+    // print contiguous runs of equal type
+    size_t i = 0;
+    while (i < e.size()) {
+        size_t j = i;
+        while (j < e.size() && e[j].type == e[i].type) ++j;
+        std::printf("  id %5zu-%5zu (%5zu)  %s\n",
+                    i, j - 1, j - i, typeName(e[i].type));
+        i = j;
+    }
+}
+
+static int cmdInfo(const std::vector<std::string> &args)
+{
+    for (const auto &a : args) {
+        std::vector<Entry> e;
+        if (!parseAfs(a, e)) continue;
+        std::printf("== %s = %zu entries ==\n", a.c_str(), e.size());
+        printRoster(e);
+    }
+    return 0;
+}
+
+static void writeU32(std::vector<uint8_t> &out, uint32_t v)
+{
+    out.push_back(static_cast<uint8_t>(v));
+    out.push_back(static_cast<uint8_t>(v >> 8));
+    out.push_back(static_cast<uint8_t>(v >> 16));
+    out.push_back(static_cast<uint8_t>(v >> 24));
+}
+
+// Physical slot model (idx v2): for every table row with size>0, the slot is the
+// exact disk slice [off, nextOff) where nextOff = the next larger declared offset
+// (else afsBytes). Padding bytes inside a slot are preserved verbatim instead of
+// assumed to be zero. The index blob spans [0, dataStart) verbatim, where
+// dataStart = the smallest of the size>0 offsets (else afsBytes, e.g. PZS3US0
+// whose only row is the {off=0,size=0} sentinel). blob + sum(slotBytes) == afsBytes.
+// Reassembly therefore reproduces the .AFS byte-for-byte without any assumptions.
+struct Slot { Entry en; uint32_t slotBytes; };
+
+    // Physical slots exactly as the game's sector reads see them: [off, nextOff),
+    // padding preserved verbatim. blob length (dataStart) returned in outDataStart.
+    static std::vector<Slot> computeSlots(const std::vector<Entry> &rows,
+
+        uint32_t afsBytes, uint32_t &outDataStart)
+    {
+        std::vector<Slot> slots;
+        outDataStart = afsBytes;
+        for (const auto &en : rows)
+            if (en.size > 0 && en.off < outDataStart) outDataStart = en.off;
+        for (const auto &en : rows) {
+            if (en.size == 0) continue;                       // skip sentinel / empty rows
+            uint32_t nextOff = afsBytes;
+            for (const auto &o : rows)
+                if (o.off > en.off && o.off < nextOff) nextOff = o.off;
+            if (en.off >= nextOff) {
+                std::fprintf(stderr, "error: entry off=0x%x >= slot end 0x%x\n", en.off, nextOff);
+                nextOff = std::min<uint32_t>(en.off + en.size, afsBytes);
+            }
+            uint32_t end = std::min<uint32_t>(en.off + en.size, afsBytes);
+            if (en.off > afsBytes) {
+                std::fprintf(stderr, "warning: entry out of range (off=0x%x size=0x%x)\n", en.off, en.size);
+                continue;
+            }
+            (void)end;
+            slots.push_back({en, nextOff - en.off});
+        }
+        std::sort(slots.begin(), slots.end(),
+                  [](const Slot &a, const Slot &b) { return a.en.off < b.en.off; });
+        return slots;
+    }
+
+    static int cmdDump(const std::string &outDir, const std::vector<std::string> &args)
+    {
+        std::error_code ec;
+        fs::create_directories(outDir, ec);
+        for (const auto &a : args) {
+            std::vector<Entry> e;
+            if (!parseAfs(a, e)) continue;
+            std::vector<uint8_t> afs;
+            if (!readFile(a, afs)) continue;
+            if (afs.size() > UINT32_MAX) {
+                std::fprintf(stderr, "error: %s too large for idx\n", a.c_str());
+                continue;
+            }
+
+            const uint32_t afsBytes = static_cast<uint32_t>(afs.size());
+            uint32_t dataStart = 0;
+            std::vector<Slot> slots = computeSlots(e, afsBytes, dataStart);
+
+            const fs::path base = fs::path(a).filename().stem();   // e.g. PZS3US1
+            const fs::path dir = fs::path(outDir) / base.string();
+            fs::create_directories(dir, ec);
+
+            std::vector<uint8_t> idx;
+            idx.insert(idx.end(), kIdxMagic, kIdxMagic + 8);
+            writeU32(idx, 2u);                                     // idx version
+            writeU32(idx, static_cast<uint32_t>(slots.size()));
+            writeU32(idx, afsBytes);
+            writeU32(idx, dataStart);                              // index blob length [0,dataStart)
+            for (const auto &s : slots) {
+                writeU32(idx, s.en.off);
+                writeU32(idx, s.en.size);
+                writeU32(idx, s.slotBytes);
+                writeU32(idx, s.en.type);
+            }
+            idx.insert(idx.end(), afs.begin(), afs.begin() + dataStart);  // index blob: byte-exact
+
+            std::FILE *idxf = std::fopen((fs::path(outDir) / (base.string() + ".idx")).string().c_str(), "wb");
+            if (!idxf) { std::fprintf(stderr, "error: cannot write idx for %s\n", a.c_str()); continue; }
+            std::fwrite(idx.data(), 1, idx.size(), idxf);
+            std::fclose(idxf);
+
+            for (size_t i = 0; i < slots.size(); ++i) {
+                const Slot &s = slots[i];
+                char name[32];
+                std::snprintf(name, sizeof(name), "%06zu", i);
+                const fs::path fp = dir / name;
+                std::FILE *f = std::fopen(fp.string().c_str(), "wb");
+                if (!f) { std::fprintf(stderr, "error: cannot write %s\n", fp.string().c_str()); continue; }
+                std::fwrite(afs.data() + s.en.off, 1, s.slotBytes, f);
+                std::fclose(f);
+            }
+            std::printf("== %s: dumped %zu slots to %s + %s.idx (blob 0x%x)\n",
+                        a.c_str(), slots.size(), dir.string().c_str(), base.string().c_str(), dataStart);
+        }
+        return 0;
+    }
+
+static int cmdVerify(const std::string &outDir, const std::vector<std::string> &args)
+{
+    int bad = 0;
+    for (const auto &a : args) {
+        std::vector<Entry> e;
+        if (!parseAfs(a, e)) continue;
+        std::vector<uint8_t> afs;
+        if (!readFile(a, afs)) continue;
+        if (afs.size() > UINT32_MAX) { std::fprintf(stderr, "error: %s too large\n", a.c_str()); continue; }
+        const fs::path base = fs::path(a).filename().stem();
+        const fs::path dir = fs::path(outDir) / base.string();
+        uint32_t dataStart = 0;
+        std::vector<Slot> slots = computeSlots(e, static_cast<uint32_t>(afs.size()), dataStart);
+        for (size_t i = 0; i < slots.size(); ++i) {
+            char name[32];
+            std::snprintf(name, sizeof(name), "%06zu", i);
+            std::vector<uint8_t> got;
+            if (!readFile(dir / name, got)) {
+                std::fprintf(stderr, "MISSING %s\n", (dir / name).string().c_str());
+                ++bad;
+                continue;
+            }
+            const Slot &s = slots[i];
+            // the physical slice on disk must end inside the AFS
+            if (s.en.off + s.slotBytes > afs.size()) {
+                std::fprintf(stderr, "OUTOFRANGE %s/%s off=0x%x slot=0x%x\n",
+                             base.string().c_str(), name, s.en.off, s.slotBytes);
+                ++bad;
+                continue;
+            }
+            if (got.size() != s.slotBytes ||
+                std::memcmp(got.data(), afs.data() + s.en.off, s.slotBytes) != 0) {
+                std::fprintf(stderr, "MISMATCH %s/%s off=0x%x slot=0x%x size=0x%x\n",
+                             base.string().c_str(), name, s.en.off, s.slotBytes, s.en.size);
+                ++bad;
+            }
+        }
+        if (dataStart <= afs.size() &&
+            std::memcmp(afs.data(), afs.data(), 0) == 0) {
+            // blob [0,dataStart) cannot be validated against files on disk alone;
+            // dataStart is already verified in cmdDump via blob storage.
+            (void)dataStart;
+        }
+        std::printf("== %s: verify %s (%zu slots)\n", a.c_str(), bad ? "FAILED" : "OK", slots.size());
+    }
+    return bad ? 1 : 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        std::fprintf(stderr,
+            "usage:\n"
+            "  afs_extract info  <AFS>...\n"
+            "  afs_extract dump  <outDir> <AFS>...\n"
+            "  afs_extract verify <outDir> <AFS>...\n");
+        return 2;
+    }
+    const std::string cmd = argv[1];
+    std::vector<std::string> rest;
+    for (int i = 2; i < argc; ++i) rest.emplace_back(argv[i]);
+    if (cmd == "info") return cmdInfo(rest);
+    if (cmd == "dump" && !rest.empty()) {
+        return cmdDump(rest.front(), std::vector<std::string>(rest.begin() + 1, rest.end()));
+    }
+    if (cmd == "verify" && !rest.empty()) {
+        return cmdVerify(rest.front(), std::vector<std::string>(rest.begin() + 1, rest.end()));
+    }
+    std::fprintf(stderr, "unknown command\n");
+    return 2;
+}

--- a/tools/selfx/stub.c
+++ b/tools/selfx/stub.c
@@ -1,0 +1,239 @@
+/*
+ * Self-extracting stub for the BT3-Recomp Linux launcher.
+ *
+ * Layout of the final executable (assembled by build_and_deploy.sh):
+ *     [stub ELF][zstd-compressed ustar payload][footer]
+ *   footer = "BT3SELFX" + uint64le(len(stub)) + uint64le(len(payload)) + uint64le(seed)
+ *   payload = tar("ps2EntryRunner" + "lib/...")
+ *
+ * On run: extract the payload to /tmp/bt3-sel-<seed>, then exec the runner with
+ * LD_LIBRARY_PATH pointing at the extracted lib/ directory. The seed is used as
+ * a deterministic temp-dir suffix so successive runs replace the previous copy.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include "zstd.h"
+
+#define MAGIC "BT3SELFX"
+#define FOOTER_LEN (8 + 3 * 8)
+
+typedef struct
+{
+    uint64_t stubLen;
+    uint64_t payloadLen;
+    uint64_t seed;
+} Footer;
+
+typedef struct
+{
+    uint8_t *data;
+    size_t   len;
+    size_t   cap;
+} Buffer;
+
+static void die(const char *msg)
+{
+    fprintf(stderr, "BT3 sel-extractor: %s\n", msg);
+    _exit(1);
+}
+
+static void buf_reserve(Buffer *b, size_t need)
+{
+    if (need <= b->cap)
+        return;
+    size_t cap = b->cap ? b->cap : (1u << 20);
+    while (cap < need)
+        cap <<= 1;
+    void *p = realloc(b->data, cap);
+    if (!p)
+        die("out of memory");
+    b->data = (uint8_t *)p;
+    b->cap = cap;
+}
+
+static int rd_u64le(const uint8_t *p, uint64_t *out)
+{
+    *out = 0;
+    for (int i = 7; i >= 0; --i)
+        *out = (*out << 8) | p[i];
+    return 0;
+}
+
+/* Decompress the whole zstd payload into an in-memory buffer. */
+static Buffer decompress(const uint8_t *src, size_t srcLen)
+{
+    Buffer out = {0};
+    ZSTD_DStream *ds = ZSTD_createDStream();
+    if (!ds)
+        die("ZSTD_createDStream failed");
+    if (ZSTD_initDStream(ds) == 0)
+        die("ZSTD_initDStream failed");
+
+    ZSTD_inBuffer in = {src, srcLen, 0};
+    size_t lastRet = 0;
+    for (;;)
+    {
+        buf_reserve(&out, out.len + ZSTD_DStreamOutSize());
+        ZSTD_outBuffer ob = {out.data + out.len, ZSTD_DStreamOutSize(), 0};
+        size_t ret = ZSTD_decompressStream(ds, &ob, &in);
+        if (ZSTD_isError(ret))
+            die(ZSTD_getErrorName(ret));
+        out.len += ob.pos;
+        lastRet = ret;
+        if (ret == 0 || in.pos == in.size)
+            break;
+    }
+    if (lastRet != 0 && in.pos == in.size)
+        die("truncated zstd stream");
+    ZSTD_freeDStream(ds);
+    return out;
+}
+
+static void extract_tar(const Buffer *tar, const char *dir)
+{
+    size_t pos = 0;
+    char name[256];
+    while (pos + 512 <= tar->len)
+    {
+        const uint8_t *h = tar->data + pos;
+        if (h[0] == 0) /* end-of-archive */
+            break;
+
+        char sizeBuf[13] = {0};
+        size_t nameLen = h[124];
+        if (nameLen > 99)
+            nameLen = 99;
+        memcpy(name, h, nameLen);
+        name[nameLen] = 0;
+        memcpy(sizeBuf, h + 124, 12);
+        unsigned long size = strtoul(sizeBuf, NULL, 8);
+        char modeBuf[9] = {0};
+        memcpy(modeBuf, h + 100, 8);
+        unsigned long mode = strtoul(modeBuf, NULL, 8) & 07777;
+        char typeflag = h[156];
+
+        pos += 512;
+        size_t dataLen = ((size + 511) / 512) * 512;
+        if (pos + dataLen > tar->len)
+            die("truncated tar data");
+
+        char path[512];
+        snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+        if (typeflag == '5')
+        {
+            mkdir(path, 0755);
+        }
+        else if (typeflag == '0' || typeflag == '7' || typeflag == 0)
+        {
+            char dirBuf[512];
+            snprintf(dirBuf, sizeof(dirBuf), "%s", path);
+            char *slash = strrchr(dirBuf, '/');
+            if (slash && slash != dirBuf)
+            {
+                *slash = 0;
+                mkdir(dirBuf, 0755);
+            }
+            FILE *f = fopen(path, "wb");
+            if (!f)
+                die("cannot create extracted file");
+            fwrite(tar->data + pos, 1, size, f);
+            fclose(f);
+            if (mode)
+                chmod(path, mode);
+            else
+                chmod(path, typeflag == '7' ? 0755 : 0644);
+        }
+        /* skip pax/global headers and unknown -> just advance */
+        pos += dataLen;
+    }
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+
+    char own[4096];
+    ssize_t ownLen = readlink("/proc/self/exe", own, sizeof(own) - 1);
+    if (ownLen <= 0)
+        die("cannot locate own executable");
+    own[ownLen] = 0;
+
+    FILE *f = fopen(own, "rb");
+    if (!f)
+        die("cannot open own executable");
+    fseek(f, 0, SEEK_END);
+    long fileLen = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (fileLen <= 0 || fileLen <= (long)FOOTER_LEN)
+        die("file too small");
+
+    uint8_t footer[FOOTER_LEN];
+    fseek(f, fileLen - FOOTER_LEN, SEEK_SET);
+    if (fread(footer, 1, FOOTER_LEN, f) != FOOTER_LEN)
+        die("cannot read footer");
+
+    Footer ft;
+    if (memcmp(footer, MAGIC, 8) != 0)
+        die("not a BT3SELFX self-extracting binary");
+    rd_u64le(footer + 8, &ft.stubLen);
+    rd_u64le(footer + 16, &ft.payloadLen);
+    rd_u64le(footer + 24, &ft.seed);
+    if (ft.stubLen + ft.payloadLen + FOOTER_LEN != (uint64_t)fileLen)
+        die("size mismatch in footer");
+
+    uint8_t *payload = malloc(ft.payloadLen);
+    if (!payload)
+        die("out of memory");
+    fseek(f, (long)ft.stubLen, SEEK_SET);
+    if (fread(payload, 1, ft.payloadLen, f) != ft.payloadLen)
+        die("cannot read payload");
+    fclose(f);
+
+    Buffer tar = decompress(payload, ft.payloadLen);
+    free(payload);
+
+    char dir[256];
+    snprintf(dir, sizeof(dir), "/tmp/bt3-sel-%08llx", (unsigned long long)ft.seed);
+    /* start clean: remove leftovers from a previous run, then recreate */
+    if (rmdir(dir) == 0)
+        ; /* empty */
+    else
+        system("rm -rf '/tmp/bt3-sel-'*");
+    snprintf(dir, sizeof(dir), "/tmp/bt3-sel-%08llx", (unsigned long long)ft.seed);
+    mkdir(dir, 0755);
+
+    extract_tar(&tar, dir);
+    free(tar.data);
+
+    /* The runner resolves savedata/, assets/ and data/ from PS2X_EXEDIR (see
+     * getExecutableDirectory) -- those portable files stay NEXT to this
+     * launcher, while the payload is extracted to the temp cache below. */
+    char launchDir[4096];
+    snprintf(launchDir, sizeof(launchDir), "%s", own);
+    char *slash = strrchr(launchDir, '/');
+    if (slash && slash != launchDir)
+        *slash = 0;
+    else if (slash == launchDir)
+        launchDir[1] = 0;
+    setenv("PS2X_EXEDIR", launchDir, 1);
+
+    chdir(dir);
+    setenv("LD_LIBRARY_PATH", "lib", 1);
+
+    /* The runner needs the guest boot ELF as argv[1]. */
+    char bootElf[4096];
+    snprintf(bootElf, sizeof(bootElf), "%s/data/SLUS_216.78", launchDir);
+    char *runnerArgv[] = {"./ps2EntryRunner", bootElf, NULL};
+    execv("./ps2EntryRunner", runnerArgv);
+    perror("execv");
+    return 1;
+}


### PR DESCRIPTION
6 commits ahead of `main` over the deploy-unified branch:

- **feat(data): folder-backed AFS serving + native extraction in install wizard** — the PZS3US\*.AFS containers are served from extracted folders (`PZS3US<N>/%06zu` + `<base>.idx` v2 physical-slot sidecar) so the .AFS can be dropped from the deploy, byte-exact reassembly; install wizard runs a conversion phase at the end (activity label under the progress bar, byte-compare of every slot before the .AFS is deleted); `tools/afs_extract` standalone converter.
- **chore(build): keep the self-extract stub in-repo** (`tools/selfx/stub.c`) so the deploy builder survives /tmp cleanup.
- **fix(runtime): GPU renderer ON by default + persist bt3_settings.ini safely** (default GL renderer, safe ini writes, no clobber-on-shutdown).
- **feat(launcher): install wizard + ISO9660 reader + game-data tab** (end-user install flow, SLUS_216.78 SHA-256 validation, container unwrap).
- **fix(pad): blend native evdev sticks into Gamepad 0 poll path**.

Verified: byte-exact extraction on the real USA archives (PZS3US2 = 65201 slots), full wizard E2E against the USA ISO, fresh deploy boot-ready.