### PR TITLE
Improve macOS packaging and streaming audio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ __pycache__/
 
 # local build trees (build_pre, build_pgs, ...)
 build_*/
+
+# Agent instructions file, local only
+AGENTS.md

--- a/games/bt3/setup.py
+++ b/games/bt3/setup.py
@@ -118,6 +118,14 @@ def cmake_configure_extra() -> list:
     extra.append("-DPS2X_BUILD_STUDIO=" + ("ON" if os.environ.get("PS2X_SETUP_STUDIO") == "1" else "OFF"))
     if IS_MACOS:
         extra += ["-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"]
+        # [pgs] paraLLEl-GS does not build on macOS: its Granite dependency's
+        # sleep_until_nsecs() falls back to clock_nanosleep/TIMER_ABSTIME for
+        # everything that is not _WIN32, and macOS has neither. CMake enables the
+        # backend whenever the submodule checkout exists, and setup.py fetches
+        # submodules, so without this a fresh macOS configure breaks the build.
+        # PS2X_SETUP_PGS=1 opts back in (needs MoltenVK and a patched Granite).
+        if os.environ.get("PS2X_SETUP_PGS") != "1":
+            extra.append("-DPS2X_DISABLE_PGS=ON")
         if os.environ.get("MACOSX_DEPLOYMENT_TARGET"):
             extra.append("-DCMAKE_OSX_DEPLOYMENT_TARGET=" + os.environ["MACOSX_DEPLOYMENT_TARGET"])
         if not (BUILD / "CMakeCache.txt").exists() and shutil.which("ninja"):
@@ -156,6 +164,14 @@ def configured() -> bool:
         desired = os.environ["MACOSX_DEPLOYMENT_TARGET"]
         if not any(line.startswith("CMAKE_OSX_DEPLOYMENT_TARGET:") and line.endswith("=" + desired)
                    for line in cache.splitlines()):
+            return False
+    if IS_MACOS:
+        # [pgs] A cache configured before the parallel-gs submodule was fetched
+        # has PS2X_DISABLE_PGS=OFF and no PGS targets; reusing it silently keeps
+        # the backend enabled on the next build and fails to compile Granite.
+        desired_pgs = "OFF" if os.environ.get("PS2X_SETUP_PGS") == "1" else "ON"
+        if not any(line.startswith("PS2X_DISABLE_PGS:") and line.endswith("=" + desired_pgs)
+                   for line in cache_text.splitlines()):
             return False
     if any((BUILD / f).exists() for f in ("build.ninja", "Makefile", "ALL_BUILD.vcxproj")):
         return True
@@ -277,7 +293,14 @@ def main() -> None:
             die("SLUS_216.78 not found in ISO (is this the USA release?)")
         make_writable(WORK)
     elif not args.skip_setup:
+        # An earlier ISO extraction leaves the whole tree read-only (ISO9660), so
+        # copying a bare ELF over a previous run's copy fails on the open. Make
+        # the tree writable first -- the game itself opens BIN/DBZP.BIN
+        # read-write, so this is needed for anything the user dropped in too.
+        if work.exists():
+            make_writable(work)
         shutil.copyfile(src, elf)
+        make_writable(work)
         print("NOTE: you passed a bare ELF. The game also needs the ISO's BIN/, IRX/")
         print(f"      and DATA/ directories next to it in {WORK}.")
 

--- a/ps2xRuntime/CMakeLists.txt
+++ b/ps2xRuntime/CMakeLists.txt
@@ -552,6 +552,16 @@ target_link_libraries(ps2_runtime PUBLIC ps2_host_backend ffmpeg)
 # ps2xRuntime/third_party/parallel-gs is a git-ignored symlink/checkout of https://github.com/Arntzen-Software/parallel-gs
 set(PS2X_PGS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/parallel-gs" CACHE PATH "paraLLEl-GS checkout (with its Granite submodule)")
 option(PS2X_DISABLE_PGS "Do not build the paraLLEl-GS backend even if the checkout is present" OFF)
+# paraLLEl-GS does not compile on macOS: Granite's sleep_until_nsecs() uses
+# clock_nanosleep/TIMER_ABSTIME for everything that is not _WIN32, and macOS has
+# neither. Gate it on the platform rather than on a cache variable alone, so a
+# regenerated cache cannot silently turn it back on. PS2X_FORCE_PGS=ON opts in
+# (needs MoltenVK and a patched Granite).
+option(PS2X_FORCE_PGS "Build paraLLEl-GS even on platforms it is not known to support" OFF)
+if (APPLE AND NOT PS2X_FORCE_PGS)
+    set(PS2X_DISABLE_PGS ON)
+    set(PS2X_PGS_SKIP_REASON "not supported on macOS (Granite needs clock_nanosleep)")
+endif()
 if (EXISTS "${PS2X_PGS_DIR}/CMakeLists.txt" AND NOT PS2X_DISABLE_PGS)
     set(PARALLEL_GS_STANDALONE ON CACHE BOOL "" FORCE)
     add_subdirectory("${PS2X_PGS_DIR}" "${CMAKE_BINARY_DIR}/parallel-gs" EXCLUDE_FROM_ALL)
@@ -560,7 +570,16 @@ if (EXISTS "${PS2X_PGS_DIR}/CMakeLists.txt" AND NOT PS2X_DISABLE_PGS)
     target_compile_definitions(ps2_runtime PUBLIC PS2X_HAVE_PGS=1)
     message(STATUS "[pgs] paraLLEl-GS backend enabled from ${PS2X_PGS_DIR}")
 else()
-    message(STATUS "[pgs] paraLLEl-GS backend not built (no checkout at ${PS2X_PGS_DIR})")
+    # Say WHICH of the three reasons applies: the old message always blamed a
+    # missing checkout, including when the backend was deliberately disabled.
+    if (PS2X_PGS_SKIP_REASON)
+        set(_pgs_why "${PS2X_PGS_SKIP_REASON}")
+    elseif (PS2X_DISABLE_PGS)
+        set(_pgs_why "PS2X_DISABLE_PGS=ON")
+    else()
+        set(_pgs_why "no checkout at ${PS2X_PGS_DIR}")
+    endif()
+    message(STATUS "[pgs] paraLLEl-GS backend not built (${_pgs_why})")
 endif()
 target_link_libraries(ps2EntryRunner
     PRIVATE

--- a/ps2xRuntime/src/launcher/Info.plist.in
+++ b/ps2xRuntime/src/launcher/Info.plist.in
@@ -6,6 +6,7 @@
     <key>CFBundleName</key><string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
     <key>CFBundleIdentifier</key><string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
     <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleIconFile</key><string>BT3-Recomp.icns</string>
     <key>CFBundleShortVersionString</key><string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
     <key>CFBundleVersion</key><string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
     <key>LSMinimumSystemVersion</key><string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>

--- a/ps2xRuntime/src/launcher/main.cpp
+++ b/ps2xRuntime/src/launcher/main.cpp
@@ -3,6 +3,8 @@
 #include "launcher_window.h"
 
 #include <QApplication>
+#include <QGuiApplication>
+#include <QScreen>
 
 int main(int argc, char *argv[])
 {
@@ -24,5 +26,14 @@ int main(int argc, char *argv[])
 
     LauncherWindow win;
     win.show();
+    // macOS can restore a stale window position from a disconnected monitor.
+    // Always bring the launcher back onto the current primary display.
+    if (QScreen *screen = QGuiApplication::primaryScreen())
+    {
+        const QRect area = screen->availableGeometry();
+        win.move(area.center() - QPoint(win.width() / 2, win.height() / 2));
+    }
+    win.raise();
+    win.activateWindow();
     return app.exec();
 }

--- a/ps2xRuntime/src/lib/ps2_audio.cpp
+++ b/ps2xRuntime/src/lib/ps2_audio.cpp
@@ -88,6 +88,12 @@ static constexpr size_t kStreamChunkFrames = 1024;
 
 struct PS2AudioBackend::Impl
 {
+    struct DeviceProgress
+    {
+        uint64_t played = 0;
+        size_t queued = 0;
+        uint32_t primingSlots = 2;
+    };
     struct TrackedSound
     {
         Sound snd;
@@ -96,6 +102,8 @@ struct PS2AudioBackend::Impl
     std::vector<TrackedSound> activeSounds;
     // Open raylib AudioStreams for the streaming-PCM path, keyed by streamId.
     std::unordered_map<uint32_t, AudioStream> streams;
+    // PCM that is still inside raylib/Core Audio rather than in StreamState::ring.
+    std::unordered_map<uint32_t, DeviceProgress> deviceProgress;
 };
 
 PS2AudioBackend::PS2AudioBackend() : m_impl(std::make_unique<Impl>())
@@ -376,7 +384,12 @@ PS2AudioBackend::StreamProgress PS2AudioBackend::streamProgress(uint32_t streamI
         return p;
     p.known = true;
     p.started = it->second.started;
-    p.consumedSamples = it->second.fed;
+    // `fed` only means that PCM was copied into raylib's double buffer.  Treating it as
+    // played returns the IOP ring immediately, so BT3 sends STOP while the first character
+    // call-out is still sitting in Core Audio.  `played` moves only when raylib reports a
+    // previously-filled sub-buffer free again.
+    auto dev = m_impl->deviceProgress.find(streamId);
+    p.consumedSamples = (dev != m_impl->deviceProgress.end()) ? dev->second.played : 0u;
     p.gapSamples = it->second.gap;
     p.pending = it->second.ring.size();
     return p;
@@ -515,6 +528,8 @@ void PS2AudioBackend::serviceStreams()
             SetAudioStreamBufferSizeDefault(static_cast<int>(kStreamChunkFrames));
             m_impl->streams[kPairKey] = LoadAudioStream(L.sampleRate, 16, 2);
             L.opened = R.opened = true;
+            m_impl->deviceProgress[kLeftId] = {};
+            m_impl->deviceProgress[kRightId] = {};
             s_pairOpenRate = L.sampleRate;
             std::fprintf(stderr, "[sndplay] opened STEREO PAIR (streams 0+1) rate=%u\n", L.sampleRate);
         }
@@ -571,6 +586,24 @@ void PS2AudioBackend::serviceStreams()
             while (IsAudioStreamProcessed(s) &&
                    std::min(L.ring.size(), R.ring.size()) >= kStreamChunkFrames)
             {
+                // A new AudioStream starts with two empty sub-buffers.  The first two
+                // processed notifications merely let us prime them; every later one means a
+                // complete stereo chunk was actually heard.
+                auto &lDev = m_impl->deviceProgress[kLeftId];
+                auto &rDev = m_impl->deviceProgress[kRightId];
+                if (lDev.primingSlots != 0u)
+                {
+                    --lDev.primingSlots;
+                    --rDev.primingSlots;
+                }
+                else if (lDev.queued >= kStreamChunkFrames &&
+                         rDev.queued >= kStreamChunkFrames)
+                {
+                    lDev.queued -= kStreamChunkFrames;
+                    rDev.queued -= kStreamChunkFrames;
+                    lDev.played += kStreamChunkFrames;
+                    rDev.played += kStreamChunkFrames;
+                }
                 for (size_t i = 0; i < kStreamChunkFrames; ++i)
                 {
                     inter[i * 2u]     = static_cast<int16_t>(L.ring[i] * musicVol);
@@ -581,6 +614,8 @@ void PS2AudioBackend::serviceStreams()
                 R.ring.erase(R.ring.begin(), R.ring.begin() + static_cast<long>(kStreamChunkFrames));
                 L.fed += kStreamChunkFrames;
                 R.fed += kStreamChunkFrames;
+                lDev.queued += kStreamChunkFrames;
+                rDev.queued += kStreamChunkFrames;
                 static std::atomic<uint32_t> pf{0};
                 const uint32_t k = pf.fetch_add(1);
                 if (k < 4u || (k % 300u) == 0u)
@@ -646,6 +681,7 @@ void PS2AudioBackend::serviceStreams()
             AudioStream s = LoadAudioStream(st.sampleRate, 16, s_channels);
             m_impl->streams[id] = s;
             st.opened = true;
+            m_impl->deviceProgress[id] = {};
             std::fprintf(stderr, "[sndplay] opened stream=%u rate=%u channels=%u\n",
                          id, st.sampleRate, s_channels);
         }
@@ -689,11 +725,8 @@ void PS2AudioBackend::serviceStreams()
         if (!st.started)
         {
             // Build several whole sub-buffers before starting, so the first refills never run
-            // dry. Reported symptom: the first word or two of every VOICE line is glitched and
-            // the rest is clean -- a textbook startup underrun. A voice line arrives as a burst,
-            // so 4 sub-buffers (~170ms) was not enough of a head start; raylib drains both
-            // sub-buffers immediately on play and then runs dry while the pump catches up.
-            // 6 sub-buffers (~256ms at 24kHz) gives that head start.
+            // dry. A voice line arrives as a burst, so the IOP needs this head start before
+            // the real device clock begins returning ring capacity.
             // The cushion MUST stay BELOW the pump's backlog target (PS2X_SNDBACKLOG, default
             // 8192) or the two deadlock: the pump stops handing buffers back once it reaches
             // the target, a larger start threshold is then never reached, and the stream never
@@ -730,6 +763,19 @@ void PS2AudioBackend::serviceStreams()
             const size_t chunk = kStreamChunkFrames * s_channels;
             if (st.ring.size() < chunk)
                 break;
+            auto &dev = m_impl->deviceProgress[id];
+            // See the paired-stream path above: do not credit the IOP until a buffer that
+            // contained audio has become free.  This holds the guest's STOP/cleanup path off
+            // for the real device latency without changing the game's stream state machine.
+            if (dev.primingSlots != 0u)
+            {
+                --dev.primingSlots;
+            }
+            else if (dev.queued >= chunk)
+            {
+                dev.queued -= chunk;
+                dev.played += chunk;
+            }
             // Apply SFX volume (master * sfx) to this chunk. Mono streams carry voices and
             // effects; scaling here is cheaper than a second ring pass.
             const float sfxVol = s_masterVolume * s_sfxVolume;
@@ -747,6 +793,7 @@ void PS2AudioBackend::serviceStreams()
             }
             st.ring.erase(st.ring.begin(), st.ring.begin() + static_cast<long>(chunk));
             st.fed += chunk;
+            dev.queued += chunk;
             static std::atomic<uint32_t> f{0};
             const uint32_t k = f.fetch_add(1);
             if (k < 6u || (k % 200u) == 0u)

--- a/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
+++ b/ps2xRuntime/src/lib/ps2_gs_gpu.cpp
@@ -3699,7 +3699,9 @@ void GS::writeRegister(uint8_t regAddr, uint64_t value)
     recordRegisterDebugEventUnlocked(regAddr, value);
 }
 
+#if defined(PS2X_HAVE_PGS)
 namespace ps2x_pgs { extern std::atomic<int> g_pgsProbeReq; extern std::atomic<unsigned> g_pgsProbeFbp, g_pgsProbeZbp; }   // [vramprobe]
+#endif
 // [rtstale] page footprint of a VRAM region: bp in blocks, bw in 64-pixel units, an inclusive pixel box in `psm`
 // pixels. Pages per row follow the format's page width; a base that is not page aligned makes every block-table
 // index >= 32 land in the NEXT LINEAR page (page + 1), which is how addrPSMT4/8/CT32 resolve it -- not the next
@@ -4087,8 +4089,12 @@ void GS::vertexKick(bool drawing)
             }
             {   // [vramprobe] the 32-sprite depth-mask pass just finished -> ask the pgs module to dump the frame alpha
                 static unsigned s_c16run = 0;
+#if defined(PS2X_HAVE_PGS)
                 if (activeContext().frame.psm == GS_PSM_CT16) { if (++s_c16run == 32u) { ps2x_pgs::g_pgsProbeFbp.store(activeContext().frame.fbp); ps2x_pgs::g_pgsProbeZbp.store(activeContext().zbuf.zbp); ps2x_pgs::g_pgsProbeReq.store(1); } }
                 else s_c16run = 0;
+#else
+                (void)s_c16run;
+#endif
             }
             if (s_censusMode == 3 && s_c16N < 48 && m_vtxCount > 0 && activeContext().frame.psm == GS_PSM_CT16)
             {   // [pgscensus] every kick into a 16-bit FRAME view: BT3's depth-mask columns (must sit on x = 8..15 mod 16 of

--- a/ps2xRuntime/src/lib/ps2_memory.cpp
+++ b/ps2xRuntime/src/lib/ps2_memory.cpp
@@ -2376,7 +2376,11 @@ void PS2Memory::stage2Loop()
 {
     ps2xEeProfAddCurrentThread("GsThread");   // [eeprof]
 #if !defined(_WIN32)
+#if defined(__APPLE__)
+    pthread_setname_np("GsThread");   // macOS names the current thread
+#else
     pthread_setname_np(pthread_self(), "GsThread");   // visible to perf/top
+#endif
 #endif
     uint64_t accNs = 0;
     uint64_t nItems = 0, nPkts = 0, busyNs = 0; size_t maxDepth = 0; auto tStat = std::chrono::steady_clock::now();

--- a/ps2xRuntime/src/lib/ps2_runtime.cpp
+++ b/ps2xRuntime/src/lib/ps2_runtime.cpp
@@ -1223,6 +1223,10 @@ bool PS2Runtime::initialize(const char *title)
         {
             std::error_code ec;
             std::filesystem::path exeDir;
+            std::filesystem::path iconPath;
+            if (const char *assetDir = std::getenv("PS2X_ASSETDIR"))
+                if (assetDir[0] != '\0')
+                    iconPath = std::filesystem::path(assetDir) / "icon.png";
             if (const char *exeDirEnv = std::getenv("PS2X_EXEDIR"))
                 if (exeDirEnv[0] != '\0')
                     exeDir = exeDirEnv;
@@ -1234,24 +1238,24 @@ bool PS2Runtime::initialize(const char *title)
                     exeDir = self.parent_path();
             }
 #endif
-            if (!exeDir.empty())
+            if (iconPath.empty() && !exeDir.empty())
             {
-                const std::filesystem::path iconPath = exeDir / "assets" / "icon.png";
-                if (std::filesystem::is_regular_file(iconPath, ec) && !ec)
+                iconPath = exeDir / "assets" / "icon.png";
+            }
+            if (std::filesystem::is_regular_file(iconPath, ec) && !ec)
+            {
+                Image icon = LoadImage(iconPath.string().c_str());
+                if (icon.data != nullptr)
                 {
-                    Image icon = LoadImage(iconPath.string().c_str());
-                    if (icon.data != nullptr)
-                    {
-                        // The deploy art is huge (7k x 5k); X11's _NET_WM_ICON
-                        // sends every pixel as one property and would exceed a
-                        // single request (BadLength). Downscale before setting.
-                        const int target = 128;
-                        if (icon.width > target || icon.height > target)
-                            ImageResize(&icon, target,
-                                        target * icon.height / icon.width);
-                        SetWindowIcon(icon);
-                        UnloadImage(icon);
-                    }
+                    // The deploy art is huge (7k x 5k); X11's _NET_WM_ICON
+                    // sends every pixel as one property and would exceed a
+                    // single request (BadLength). Downscale before setting.
+                    const int target = 128;
+                    if (icon.width > target || icon.height > target)
+                        ImageResize(&icon, target,
+                                    target * icon.height / icon.width);
+                    SetWindowIcon(icon);
+                    UnloadImage(icon);
                 }
             }
         }

--- a/tools/macos/deploy.py
+++ b/tools/macos/deploy.py
@@ -25,6 +25,22 @@ def version(value):
     return tuple((list(map(int, value.split("."))) + [0, 0])[:3])
 
 
+def make_icns(source, destination, workdir):
+    """Convert the launcher artwork to the native Finder/Dock icon format."""
+    iconset = workdir / "BT3-Recomp.iconset"
+    iconset.mkdir()
+    # iconutil requires square source images. Crop the artwork around its center
+    # before generating the standard 1x/2x icon sizes.
+    square = workdir / "icon-square.png"
+    run("sips", "-c", "5178", "5178", source, "--out", square)
+    for size in (16, 32, 128, 256, 512):
+        run("sips", "-z", str(size), str(size), square,
+            "--out", iconset / f"icon_{size}x{size}.png")
+        run("sips", "-z", str(size * 2), str(size * 2), square,
+            "--out", iconset / f"icon_{size}x{size}@2x.png")
+    run("iconutil", "-c", "icns", iconset, "-o", destination)
+
+
 def audit(app, minimum):
     """Reject unresolved external libraries and a falsely advertised OS floor."""
     required_arches = set(output("lipo", "-archs", app / "Contents/MacOS/bt3-runner").split())
@@ -69,7 +85,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--iso", type=Path, help="BT3 USA ISO (SLUS-21678)")
     parser.add_argument("--output", type=Path, default=ROOT / "build/macos-dist/BT3-Recomp.app",
-                        help="destination .app; must not already exist")
+                        help="destination .app; replaced only after packaging and verification succeed")
     parser.add_argument("--jobs", type=int, default=3)
     parser.add_argument("--skip-setup", action="store_true", help="reuse generated sources and rebuild")
     parser.add_argument("--skip-build", action="store_true", help="package existing build products only")
@@ -83,8 +99,8 @@ def main():
     if not args.skip_setup and not args.skip_build and not args.iso:
         parser.error("provide --iso, --skip-setup or --skip-build")
     dest = args.output.expanduser().absolute()
-    if dest.suffix != ".app" or dest.exists():
-        parser.error("--output must name a new .app path")
+    if dest.suffix != ".app":
+        parser.error("--output must name a .app path")
     build = Path(os.environ.get("PS2X_BUILD_DIR") or ROOT / "build").resolve()
     qt = Path(output("brew", "--prefix", "qt"))
     deployqt = qt / "bin/macdeployqt"
@@ -120,6 +136,7 @@ def main():
         info = plistlib.loads(plist.read_bytes())
         info["LSMinimumSystemVersion"] = args.deployment_target
         plist.write_bytes(plistlib.dumps(info))
+        make_icns(resources / "assets/icon.png", resources / "BT3-Recomp.icns", Path(tmp))
         # Homebrew's Qt plugins use @rpath for non-Qt dependencies. macdeployqt
         # only searches Qt's own prefix by default, so provide every installed
         # formula lib directory and let it close the complete dependency graph.
@@ -149,7 +166,21 @@ def main():
             run("codesign", "--force", "--sign", "-", framework)
         run("codesign", "--force", "--sign", "-", app)
         run("codesign", "--verify", "--deep", "--strict", app)
-        app.rename(dest)
+        # Keep one predictable app path for local use.  Retain the previous bundle until the
+        # newly staged bundle has passed deployment and signature verification, so a failed
+        # publish never leaves the user without a runnable app.
+        previous = Path(tmp) / "previous.app"
+        had_previous = dest.exists()
+        if had_previous:
+            dest.rename(previous)
+        try:
+            app.rename(dest)
+        except Exception:
+            if had_previous:
+                previous.rename(dest)
+            raise
+        if had_previous:
+            shutil.rmtree(previous)
     print(f"Ready: {dest}\nGame data and saves: ~/Library/Application Support/BT3-Recomp")
     print("Local ad-hoc signature; Developer ID and notarization are not performed.")
 


### PR DESCRIPTION
## Summary
- add native macOS app icon support and center the launcher on startup
- make macOS packaging replace the canonical `BT3-Recomp.app` only after verification succeeds
- fix streamed PCM playback progress so combat voices and music reach the device reliably
- avoid building paraLLEl-GS on macOS and apply Apple-specific runtime build fixes

## Validation
- `cmake --build build --target ps2EntryRunner -j12`
- `codesign --verify --deep --strict build/macos-dist/BT3-Recomp.app`
- verified combat voices and music manually on macOS